### PR TITLE
FEAT: Implementation of render a matrix/split layout

### DIFF
--- a/lib/matrix_keyboard_layouts.dart
+++ b/lib/matrix_keyboard_layouts.dart
@@ -1,0 +1,31 @@
+class MatrixLayout {
+  final String name;
+  final List<List<String>> keys;
+
+  const MatrixLayout({required this.name, required this.keys});
+}
+
+const matrixQwerty = MatrixLayout(
+  name: 'QWERTY',
+  keys: [
+    ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', '[', ']'],
+    ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L', ';', "'"],
+    ['Z', 'X', 'C', 'V', 'B', 'N', 'M', ',', '.', '/'],
+    [' '],
+  ],
+);
+
+const matrixCanaria = MatrixLayout(
+  name: 'Canaria',
+  keys: [
+    ["W", "L", "Y", "P", "B", "F", "J", "O", "U", "'", "[", "]"],
+    ["C", "R", "S", "T", "G", "M", "N", "E", "I", "A", ";"],
+    ["Q", "Z", "V", "D", "K", "X", "H", "/", ",", "."],
+    [" "],
+  ],
+);
+
+final List<MatrixLayout> availableMatrixLayout = [
+  matrixQwerty,
+  matrixCanaria,
+];

--- a/lib/preferences_window.dart
+++ b/lib/preferences_window.dart
@@ -7,6 +7,7 @@ import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:overkeys/keyboard_layouts.dart';
+import 'package:overkeys/matrix_keyboard_layouts.dart';
 
 class PreferencesWindow extends StatefulWidget {
   const PreferencesWindow({super.key, required this.windowController});
@@ -23,6 +24,7 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
   String _currentTab = 'General';
 
   String _keyboardLayoutName = 'QWERTY';
+  String _matrixKeyboardLayoutName = 'QWERTY';
   String _fontStyle = 'GeistMono';
   double _keyFontSize = 20;
   double _spaceFontSize = 14;
@@ -43,6 +45,8 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
   double _opacity = 0.6;
   int _autoHideDuration = 2;
   bool _launchAtStartup = false;
+  bool _isMatrix = false;
+  bool _isSplit = false;
 
   @override
   void initState() {
@@ -60,6 +64,8 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
   Future<void> _loadPreferences() async {
     String keyboardLayoutName =
         await asyncPrefs.getString('layout') ?? 'QWERTY';
+    String matrixKeyboardLayoutName = 
+        await asyncPrefs.getString('matrix_layout') ?? 'QWERTY';
     String fontStyle = await asyncPrefs.getString('fontStyle') ?? 'GeistMono';
     double keyFontSize = await asyncPrefs.getDouble('keyFontSize') ?? 20;
     double spaceFontSize = await asyncPrefs.getDouble('spaceFontSize') ?? 14;
@@ -88,9 +94,12 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
     double opacity = await asyncPrefs.getDouble('opacity') ?? 0.6;
     int autoHideDuration = await asyncPrefs.getInt('autoHideDuration') ?? 2;
     bool launchAtStartup = await asyncPrefs.getBool('launchAtStartup') ?? false;
+    bool isMatrix = await asyncPrefs.getBool('isMatrix') ?? false;
+    bool isSplit = await asyncPrefs.getBool('isSplit') ?? false;
 
     setState(() {
       _keyboardLayoutName = keyboardLayoutName;
+      _matrixKeyboardLayoutName = matrixKeyboardLayoutName;
       _fontStyle = fontStyle;
       _keyFontSize = keyFontSize;
       _spaceFontSize = spaceFontSize;
@@ -111,11 +120,14 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
       _opacity = opacity;
       _autoHideDuration = autoHideDuration;
       _launchAtStartup = launchAtStartup;
+      _isMatrix = isMatrix;
+      _isSplit = isSplit;
     });
   }
 
   Future<void> _savePreferences() async {
     await asyncPrefs.setString('layout', _keyboardLayoutName);
+    await asyncPrefs.setString('matrix_layout', _matrixKeyboardLayoutName);
     await asyncPrefs.setString('fontStyle', _fontStyle);
     await asyncPrefs.setDouble('keyFontSize', _keyFontSize);
     await asyncPrefs.setDouble('spaceFontSize', _spaceFontSize);
@@ -137,6 +149,8 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
     await asyncPrefs.setDouble('opacity', _opacity);
     await asyncPrefs.setInt('autoHideDuration', _autoHideDuration);
     await asyncPrefs.setBool('launchAtStartup', _launchAtStartup);
+    await asyncPrefs.setBool('isMatrix', _isMatrix);
+    await asyncPrefs.setBool('isSplit', _isSplit);
   }
 
   void _updateMainWindow(dynamic method, dynamic value) async {
@@ -262,6 +276,19 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
             availableLayouts.map((layout) => (layout.name)).toList(), (value) {
           setState(() => _keyboardLayoutName = value!);
           _updateMainWindow('updateLayout', value);
+        }),
+        _buildDropdownOption('Matrix layout', '', _matrixKeyboardLayoutName,
+            availableMatrixLayout.map((layout) => (layout.name)).toList(), (value) {
+          setState(() => _matrixKeyboardLayoutName = value!);
+          _updateMainWindow('updateLayout', value);
+        }),
+        _buildToggleMatrixKeyboard('Use matrix layout', _isMatrix, (value) {
+          setState(() => _isMatrix = value);
+          _updateMainWindow('updateIsMatrix', value);
+        }),
+        _buildToggleSplitKeyboard('Split layout', _isSplit, (value) {
+          setState(() => _isSplit = value);
+          _updateMainWindow('updateIsSplit', value);
         }),
         _buildSliderOption('Opacity', _opacity, 0.1, 1.0, 18, (value) {
           setState(() => _opacity = value);
@@ -531,6 +558,40 @@ class _PreferencesWindowState extends State<PreferencesWindow> {
       ),
     );
   }
+
+  Widget _buildToggleMatrixKeyboard(
+    String label, bool value, Function(bool) onChanged) {
+      return _buildOptionContainer(
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(label, style: const TextStyle(color: Colors.white)),
+            Switch(
+              value: value, 
+              onChanged: onChanged,
+              activeColor: Colors.green,
+              ),
+          ],
+        )
+      );
+    }
+    
+  Widget _buildToggleSplitKeyboard(
+    String label, bool value, Function(bool) onChanged) {
+      return _buildOptionContainer(
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(label, style: const TextStyle(color: Colors.white)),
+            Switch(
+              value: value, 
+              onChanged: onChanged,
+              activeColor: Colors.green,
+              ),
+          ],
+        )
+      );
+    }
 
   Widget _buildDropdownOption(String label, String subtitle, String value,
       List<String> options, Function(String?) onChanged) {


### PR DESCRIPTION
### Helping again here, don't know if you already have this feature finished but seems like this is my last grain of arena in this project.

> [!CAUTION]
> This PR is a **WIP** and mainly incomplete, creating this PR to help with the matrix render of the layout.

## Summary
I added the file of `matrix_keyboard_layouts.dart` where you can save the matrix layouts instead of having the layouts all mixed up.

Created functions like `_adjustKeyboardLayout` to render the matrix view properly since there are 26 letters and 7 symbols which results in an uneven matrix.

### Preview
![image](https://github.com/user-attachments/assets/5392fdc0-e54a-401d-a265-5377031cd2ac)

Currently this is enabled via the preferences windows like so:

![image](https://github.com/user-attachments/assets/5d529e7c-3160-487e-9fe3-4eb489fabe8b)

> Why is there a Matrix and Split toggle?
From my personal pov, it's better to have the decision to split the layout in half like any other ergo/ortho keyboard and learn a little bit better to touch type while seeing the layout on screen.
In this case if the user is using a normal ortho non-split keeb like the [Planck](https://www.mechkeybs.com/wp-content/uploads/2020/12/OLKB-Planck-Mechanical-Keyboard-1-e1625444097483.jpg) the user have the possibility to render "unibody" matrix layout.

Current issues/bugs with these changes:
 - In the preview there is the duplicate `space` key in the third row and the spacebar below
 - Missing `]`, but seems like it doesn't needs to appear since the layouts tested they hold the same value or a symbol.
 - When `isMatrix` is false the layouts appears with a small key size
 - If `isMatrix` is true, the keys doesn't change size in settings
 - Missing `isSplit` implementation to add the `Container()` modifier to the layout.
   - You can add this condition just by adding an `if` condition here:
   `if (keyIndex == 5) {
      return Container(width: 20); }`