### PR TITLE
feat: add auto-hide on startup functionality

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -286,6 +286,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
               }
             }
           });
+          _setupTray();
+
         default:
           throw UnimplementedError('Unimplemented method ${call.method}');
       }
@@ -415,9 +417,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
       MenuItem(
         key: 'exit',
         label: 'Exit',
-        onClick: (menuItem) {
-          windowManager.close();
-        },
       ),
     ]));
   }
@@ -431,6 +430,14 @@ class _MainAppState extends State<MainApp> with TrayListener {
               id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
         }
       });
+    } else if (menuItem.key == 'exit') {
+      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
+        for (final id in windowIds) {
+          WindowController.fromWindowId(id).close();
+        }
+        windowManager.close();
+      });
+      return;
     }
     _setupTray();
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -435,8 +435,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
         for (final id in windowIds) {
           WindowController.fromWindowId(id).close();
         }
-        windowManager.close();
       });
+      windowManager.close();
       return;
     }
     _setupTray();

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -273,6 +273,19 @@ class _MainAppState extends State<MainApp> with TrayListener {
               _handleDisable();
             }
           });
+        case 'updateAutoHideEnabled':
+          final autoHideEnabled = call.arguments as bool;
+          setState(() {
+            _autoHideEnabled = autoHideEnabled;
+            if (_autoHideEnabled) {
+              _resetAutoHideTimer();
+            } else {
+              _autoHideTimer?.cancel();
+              if (!_isWindowVisible) {
+                _fadeIn();
+              }
+            }
+          });
         default:
           throw UnimplementedError('Unimplemented method ${call.method}');
       }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -424,6 +424,14 @@ class _MainAppState extends State<MainApp> with TrayListener {
 
   @override
   void onTrayMenuItemClick(MenuItem menuItem) {
+    if (menuItem.key == 'toggle_auto_hide') {
+      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
+        for (final id in windowIds) {
+          DesktopMultiWindow.invokeMethod(
+              id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
+        }
+      });
+    }
     _setupTray();
   }
 

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -45,6 +45,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   double _opacity = 0.6;
   int _autoHideDuration = 2;
   bool _launchAtStartup = false;
+  bool _autoHideEnabled = false;
 
   @override
   void initState() {
@@ -93,6 +94,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     double opacity = await asyncPrefs.getDouble('opacity') ?? 0.6;
     int autoHideDuration = await asyncPrefs.getInt('autoHideDuration') ?? 2;
     bool launchAtStartup = await asyncPrefs.getBool('launchAtStartup') ?? false;
+    bool autoHideEnabled = await asyncPrefs.getBool('autoHideEnabled') ?? false;
 
     setState(() {
       _keyboardLayoutName = keyboardLayoutName;
@@ -118,6 +120,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
       _opacity = opacity;
       _autoHideDuration = autoHideDuration;
       _launchAtStartup = launchAtStartup;
+      _autoHideEnabled = autoHideEnabled;
     });
   }
 
@@ -146,6 +149,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     await asyncPrefs.setDouble('opacity', _opacity);
     await asyncPrefs.setInt('autoHideDuration', _autoHideDuration);
     await asyncPrefs.setBool('launchAtStartup', _launchAtStartup);
+    await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
   }
 
   void _updateMainWindow(dynamic method, dynamic value) async {
@@ -266,6 +270,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
         _buildToggleOption('Open on system startup', _launchAtStartup, (value) {
           setState(() => _launchAtStartup = value);
           _updateMainWindow('updateLaunchAtStartup', value);
+        }),
+        _buildToggleOption('Auto-hide keyboard', _autoHideEnabled, (value) {
+          setState(() => _autoHideEnabled = value);
+          _updateMainWindow('updateAutoHideEnabled', value);
         }),
         _buildDropdownOption('Layout', _keyboardLayoutName,
             availableLayouts.map((layout) => (layout.name)).toList(), (value) {

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -52,6 +52,17 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
     super.initState();
     // asyncPrefs.clear();
     _loadPreferences();
+    _setupMethodHandler();
+  }
+
+  void _setupMethodHandler() {
+    DesktopMultiWindow.setMethodHandler((call, fromWindowId) async {
+      if (call.method == 'updateAutoHideFromMainWindow' && mounted) {
+        setState(() => _autoHideEnabled = call.arguments as bool);
+        await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
+      }
+      return null;
+    });
   }
 
   @override


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable auto-hide functionality for the keyboard. The changes span multiple files and involve updating the state management and preferences handling.

Key changes include:

### Auto-hide Functionality Implementation:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR276-R290): Added handling for the `updateAutoHideEnabled` method to update the auto-hide state and reset or cancel the auto-hide timer accordingly. Also, updated the tray menu item click handling to propagate the auto-hide state to all sub-windows. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR276-R290) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL405-R441)

### Preferences Screen Updates:

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R48-R65): Introduced a new boolean `_autoHideEnabled` to manage the auto-hide state. Updated the preferences loading and saving methods to include this new state. Added a method handler to update the auto-hide state from the main window and included a new toggle option in the UI for enabling or disabling auto-hide. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R48-R65) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R108) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R134) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R163) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R285-R288)