### PR TITLE
fix: resolve auto-hide issue when moving window

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -364,6 +364,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     _resetAutoHideTimer();
   }
 
+  bool autoHideBeforeMove = false;
   Future<void> _setupTray() async {
     String iconPath = Platform.isWindows
         ? 'assets/images/app_icon.ico'
@@ -383,10 +384,16 @@ class _MainAppState extends State<MainApp> with TrayListener {
             _ignoreMouseEvents = !_ignoreMouseEvents;
             windowManager.setIgnoreMouseEvents(_ignoreMouseEvents);
             if (!_ignoreMouseEvents) {
+              autoHideBeforeMove = _autoHideEnabled;
               _autoHideEnabled = false;
               _autoHideTimer?.cancel();
               if (!_isWindowVisible) {
                 _fadeIn();
+              }
+            } else {
+              _autoHideEnabled = autoHideBeforeMove;
+              if (_autoHideEnabled) {
+                _resetAutoHideTimer();
               }
             }
           });

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -382,6 +382,13 @@ class _MainAppState extends State<MainApp> with TrayListener {
             }
             _ignoreMouseEvents = !_ignoreMouseEvents;
             windowManager.setIgnoreMouseEvents(_ignoreMouseEvents);
+            if (!_ignoreMouseEvents) {
+              _autoHideEnabled = false;
+              _autoHideTimer?.cancel();
+              if (!_isWindowVisible) {
+                _fadeIn();
+              }
+            }
           });
           _fadeIn();
         },

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -425,6 +425,13 @@ class _MainAppState extends State<MainApp> with TrayListener {
       ),
       MenuItem.separator(),
       MenuItem(
+          key: 'reset_position',
+          label: 'Reset Position',
+          onClick: (menuItem) {
+            windowManager.setAlignment(Alignment.bottomCenter);
+          }),
+      MenuItem.separator(),
+      MenuItem(
         key: 'preferences',
         label: 'Preferences',
         onClick: (menuItem) {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -405,6 +405,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
         key: 'toggle_auto_hide',
         label: 'Auto Hide',
         checked: _autoHideEnabled,
+        disabled: !_ignoreMouseEvents,
         onClick: (menuItem) {
           setState(() {
             if (kDebugMode) {


### PR DESCRIPTION
This PR addresses issue #8.
* Added a new boolean variable `autoHideBeforeMove` to manage the auto-hide state before moving the window.
* Updated the `Move` tray menu item to temporarily disable the auto-hide behavior, ensuring the window remains visible when necessary and preventing the bug from happening.
* Disabled the `Auto-hide` tray menu item when `Move` is on, preventing unintended behavior.
* Added a new menu item `Reset Position` to the tray menu, allowing users to reset the window position to the bottom center of the screen.