### PR TITLE
feat: add support for multiple/alternative keyboard layout

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -76,7 +76,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
   double _splitWidth = 100;
 
   // Text settings
-  String _fontStyle = 'GeistMono';
+  String _fontFamily = 'GeistMono';
   double _keyFontSize = 20;
   double _spaceFontSize = 14;
   FontWeight _fontWeight = FontWeight.w600;
@@ -272,7 +272,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     double splitWidth = await asyncPrefs.getDouble('splitWidth') ?? 100;
 
     // Text settings
-    String fontStyle = await asyncPrefs.getString('fontStyle') ?? 'GeistMono';
+    String fontFamily = await asyncPrefs.getString('fontFamily') ?? 'GeistMono';
     double keyFontSize = await asyncPrefs.getDouble('keyFontSize') ?? 20;
     double spaceFontSize = await asyncPrefs.getDouble('spaceFontSize') ?? 14;
     FontWeight fontWeight = FontWeight
@@ -315,7 +315,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
       _splitWidth = splitWidth;
 
       // Text settings
-      _fontStyle = fontStyle;
+      _fontFamily = fontFamily;
       _keyFontSize = keyFontSize;
       _spaceFontSize = spaceFontSize;
       _fontWeight = fontWeight;
@@ -356,7 +356,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     await asyncPrefs.setDouble('splitWidth', _splitWidth);
 
     // Text settings
-    await asyncPrefs.setString('fontStyle', _fontStyle);
+    await asyncPrefs.setString('fontFamily', _fontFamily);
     await asyncPrefs.setDouble('keyFontSize', _keyFontSize);
     await asyncPrefs.setDouble('spaceFontSize', _spaceFontSize);
     await asyncPrefs.setInt('fontWeight', _fontWeight.index);
@@ -509,9 +509,9 @@ class _MainAppState extends State<MainApp> with TrayListener {
           setState(() => _splitWidth = splitWidth);
 
         // Text settings
-        case 'updateFontStyle':
-          final fontStyle = call.arguments as String;
-          setState(() => _fontStyle = fontStyle);
+        case 'updateFontFamily':
+          final fontFamily = call.arguments as String;
+          setState(() => _fontFamily = fontFamily);
         case 'updateKeyFontSize':
           final keyFontSize = call.arguments as double;
           setState(() => _keyFontSize = keyFontSize);
@@ -752,7 +752,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     return MaterialApp(
       title: 'OverKeys',
       theme: ThemeData(
-          fontFamily: _fontStyle,
+          fontFamily: _fontFamily,
           fontFamilyFallback: const ['GeistMono', 'Manrope', 'sans-serif']),
       home: Scaffold(
           backgroundColor: Colors.transparent,
@@ -787,7 +787,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
                     keyPadding: _keyPadding,
                     spaceWidth: _spaceWidth,
                     splitWidth: _splitWidth,
-                    fontStyle: _fontStyle,
                     keyFontSize: _keyFontSize,
                     spaceFontSize: _spaceFontSize,
                     fontWeight: _fontWeight,

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -106,7 +106,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
       }
       if (_showAltLayout) {
         _loadAltLayout();
-      }   
+      }
       if (_kanataEnabled) {
         _kanataService.connect();
       }
@@ -433,6 +433,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
           if (showAltLayout) {
             _loadAltLayout();
           }
+          _fadeIn();
         case 'updateKanataEnabled':
           final kanataEnabled = call.arguments as bool;
           setState(() {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -50,6 +50,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
   KeyboardLayout _keyboardLayout = qwerty;
   KeyboardLayout? _initialKeyboardLayout;
   bool _useUserLayout = false;
+  KeyboardLayout? _altLayout;
+  bool _showAltLayout = false;
   bool _kanataEnabled = false;
 
   // Appearance settings
@@ -102,6 +104,9 @@ class _MainAppState extends State<MainApp> with TrayListener {
       if (_useUserLayout) {
         _loadUserLayout();
       }
+      if (_showAltLayout) {
+        _loadAltLayout();
+      }   
       if (_kanataEnabled) {
         _kanataService.connect();
       }
@@ -174,6 +179,21 @@ class _MainAppState extends State<MainApp> with TrayListener {
     }
   }
 
+  Future<void> _loadAltLayout() async {
+    if (!_showAltLayout) return;
+    final configService = ConfigService();
+    final altLayout = await configService.getAltLayout();
+
+    if (altLayout != null) {
+      setState(() {
+        _altLayout = altLayout;
+      });
+      if (kDebugMode) {
+        print('Loaded alt layout: ${altLayout.name}');
+      }
+    }
+  }
+
   Future<void> _loadKanataConfig() async {
     final configService = ConfigService();
     final config = await configService.loadConfig();
@@ -182,24 +202,23 @@ class _MainAppState extends State<MainApp> with TrayListener {
       _kanataService.updateSettings(
           config.kanataHost, config.kanataPort, config.userLayouts);
 
-      final defaultLayout =
-          _kanataService.getLayoutByName(config.defaultUserLayout);
-      if (defaultLayout != null) {
-        setState(() {
+      final defaultLayout = await configService.getUserLayout();
+      setState(() {
+        if (defaultLayout != null) {
           _keyboardLayout = defaultLayout;
-        });
-      }
+        }
+      });
     }
   }
 
   Future<void> _adjustWindowSize() async {
     _fadeIn();
     double height = _showTopRow
-      ? _defaultWindowHeight + _defaultTopRowExtraHeight
-      : _defaultWindowHeight;
+        ? _defaultWindowHeight + _defaultTopRowExtraHeight
+        : _defaultWindowHeight;
     double width = _showTopRow
-      ? _defaultWindowWidth + _defaultTopRowExtraWidth
-      : _defaultWindowWidth;
+        ? _defaultWindowWidth + _defaultTopRowExtraWidth
+        : _defaultWindowWidth;
     await windowManager.setSize(Size(width, height));
     await windowManager.setAlignment(Alignment.bottomCenter);
   }
@@ -222,6 +241,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     String keyboardLayoutName =
         await asyncPrefs.getString('layout') ?? 'QWERTY';
     bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
+    bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
     bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
 
     // Appearance settings
@@ -270,6 +290,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
           .firstWhere((layout) => layout.name == keyboardLayoutName);
       _initialKeyboardLayout = _keyboardLayout;
       _useUserLayout = useUserLayout;
+      _showAltLayout = showAltLayout;
+      _altLayout = _keyboardLayout;
       _kanataEnabled = kanataEnabled;
 
       // Appearance settings
@@ -308,6 +330,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     await asyncPrefs.setDouble('autoHideDuration', _autoHideDuration);
     await asyncPrefs.setString('layout', _initialKeyboardLayout!.name);
     await asyncPrefs.setBool('useUserLayout', _useUserLayout);
+    await asyncPrefs.setBool('showAltLayout', _showAltLayout);
     await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
 
     // Appearance settings
@@ -402,6 +425,14 @@ class _MainAppState extends State<MainApp> with TrayListener {
               _fadeIn();
             }
           });
+        case 'updateShowAltLayout':
+          final showAltLayout = call.arguments as bool;
+          setState(() {
+            _showAltLayout = showAltLayout;
+          });
+          if (showAltLayout) {
+            _loadAltLayout();
+          }
         case 'updateKanataEnabled':
           final kanataEnabled = call.arguments as bool;
           setState(() {
@@ -739,27 +770,29 @@ class _MainAppState extends State<MainApp> with TrayListener {
                   child: KeyboardScreen(
                     keyPressStates: _keyPressStates,
                     layout: _keyboardLayout,
-                    fontStyle: _fontStyle,
-                    keyFontSize: _keyFontSize,
-                    spaceFontSize: _spaceFontSize,
-                    fontWeight: _fontWeight,
-                    keyTextColor: _keyTextColor,
-                    keyTextColorNotPressed: _keyTextColorNotPressed,
+                    showAltLayout: _showAltLayout,
+                    altLayout: _altLayout,
                     keyColorPressed: _keyColorPressed,
                     keyColorNotPressed: _keyColorNotPressed,
-                    keySize: _keySize,
-                    keyBorderRadius: _keyBorderRadius,
-                    keyPadding: _keyPadding,
                     markerColor: _markerColor,
                     markerColorNotPressed: _markerColorNotPressed,
                     markerOffset: _markerOffset,
                     markerWidth: _markerWidth,
                     markerHeight: _markerHeight,
                     markerBorderRadius: _markerBorderRadius,
-                    spaceWidth: _spaceWidth,
                     keymapStyle: _keymapStyle,
-                    splitWidth: _splitWidth,
                     showTopRow: _showTopRow,
+                    keySize: _keySize,
+                    keyBorderRadius: _keyBorderRadius,
+                    keyPadding: _keyPadding,
+                    spaceWidth: _spaceWidth,
+                    splitWidth: _splitWidth,
+                    fontStyle: _fontStyle,
+                    keyFontSize: _keyFontSize,
+                    spaceFontSize: _spaceFontSize,
+                    fontWeight: _fontWeight,
+                    keyTextColor: _keyTextColor,
+                    keyTextColorNotPressed: _keyTextColorNotPressed,
                   ),
                 ),
               ),

--- a/lib/models/user_config.dart
+++ b/lib/models/user_config.dart
@@ -5,6 +5,7 @@ class UserConfig {
   int kanataPort;
   List<KeyboardLayout> userLayouts;
   String defaultUserLayout;
+  String altLayout;
 
   UserConfig({
     this.kanataHost = '127.0.0.1',
@@ -32,6 +33,7 @@ class UserConfig {
       ),
     ],
     this.defaultUserLayout = 'Symbol',
+    this.altLayout = 'Symbol',
   });
 
   factory UserConfig.fromJson(Map<String, dynamic> json) {
@@ -52,6 +54,7 @@ class UserConfig {
       kanataPort: json['kanataPort'] ?? 4039,
       userLayouts: layers,
       defaultUserLayout: json['defaultUserLayout'] ?? 'QWERTY',
+      altLayout: json['altLayout'] ?? 'QWERTY',
     );
   }
 
@@ -68,6 +71,7 @@ class UserConfig {
       'kanataPort': kanataPort,
       'userLayouts': layersJson,
       'defaultUserLayout': defaultUserLayout,
+      'altLayout': altLayout,
     };
   }
 }

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -117,27 +117,70 @@ class KeyboardScreen extends StatelessWidget {
           color: keyColor,
           borderRadius: BorderRadius.circular(keyBorderRadius),
         ),
-        child: Center(
-          child: key == " "
-              ? Text(
-                  layout.name.toLowerCase(),
+        child: key == " "
+            ? Center(
+                child: Text(
+                  showAltLayout && altLayout != null
+                      ? "${layout.name.toLowerCase()} (${altLayout!.name.toLowerCase()})"
+                      : layout.name.toLowerCase(),
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: textColor,
                     fontSize: spaceFontSize,
                     fontWeight: fontWeight,
                   ),
-                )
-              : Text(
-                  key,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: textColor,
-                    fontSize: key.length > 2 ? keyFontSize * 0.7 : keyFontSize,
-                    fontWeight: fontWeight,
-                  ),
                 ),
-        ),
+              )
+            : showAltLayout && altLayout != null
+                ? Stack(
+                    children: [
+                      // Primary layout key (top left)
+                      Positioned(
+                        top: 4,
+                        left: 4,
+                        child: Text(
+                          key,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: key.length > 2
+                                ? keyFontSize * 0.6
+                                : keyFontSize * 0.85,
+                            fontWeight: fontWeight,
+                          ),
+                        ),
+                      ),
+                      // Alt layout key (bottom right)
+                      Positioned(
+                        bottom: 4,
+                        right: 4,
+                        child: Text(
+                          _getAltLayoutKey(rowIndex, keyIndex),
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize:
+                                _getAltLayoutKey(rowIndex, keyIndex).length > 2
+                                    ? keyFontSize * 0.6
+                                    : keyFontSize * 0.85,
+                            fontWeight: fontWeight,
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : Center(
+                    child: Text(
+                      key,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize:
+                            key.length > 2 ? keyFontSize * 0.7 : keyFontSize,
+                        fontWeight: fontWeight,
+                      ),
+                    ),
+                  ),
       ),
     );
 
@@ -161,7 +204,19 @@ class KeyboardScreen extends StatelessWidget {
         ],
       );
     }
-
     return keyWidget;
+  }
+
+  String _getAltLayoutKey(int rowIndex, int keyIndex) {
+    if (altLayout == null || rowIndex >= altLayout!.keys.length) {
+      return "";
+    }
+
+    List<String> altRow = altLayout!.keys[rowIndex];
+    if (keyIndex >= altRow.length) {
+      return "";
+    }
+
+    return altRow[keyIndex];
   }
 }

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -135,10 +135,10 @@ class KeyboardScreen extends StatelessWidget {
                       // Primary layout key (top left)
                       Positioned(
                         top: 4,
-                        left: 4,
+                        left: 8,
                         child: Text(
                           key,
-                          textAlign: TextAlign.center,
+                          textAlign: TextAlign.left,
                           style: TextStyle(
                             color: textColor,
                             fontSize: key.length > 2
@@ -151,10 +151,10 @@ class KeyboardScreen extends StatelessWidget {
                       // Alt layout key (bottom right)
                       Positioned(
                         bottom: 4,
-                        right: 4,
+                        right: 8,
                         child: Text(
                           _getAltLayoutKey(rowIndex, keyIndex),
-                          textAlign: TextAlign.center,
+                          textAlign: TextAlign.right,
                           style: TextStyle(
                             color: textColor,
                             fontSize:

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -5,53 +5,57 @@ import '../models/mappings.dart';
 class KeyboardScreen extends StatelessWidget {
   final Map<String, bool> keyPressStates;
   final KeyboardLayout layout;
-  final String fontStyle;
-  final double keyFontSize;
-  final double spaceFontSize;
-  final FontWeight fontWeight;
-  final Color keyTextColor;
-  final Color keyTextColorNotPressed;
+  final bool showAltLayout;
+  final KeyboardLayout? altLayout;
   final Color keyColorPressed;
   final Color keyColorNotPressed;
-  final double keySize;
-  final double keyBorderRadius;
-  final double keyPadding;
   final Color markerColor;
   final Color markerColorNotPressed;
   final double markerOffset;
   final double markerWidth;
   final double markerHeight;
   final double markerBorderRadius;
-  final double spaceWidth;
   final String keymapStyle;
-  final double splitWidth;
   final bool showTopRow;
+  final double keySize;
+  final double keyBorderRadius;
+  final double keyPadding;
+  final double spaceWidth;
+  final double splitWidth;
+  final String fontStyle;
+  final double keyFontSize;
+  final double spaceFontSize;
+  final FontWeight fontWeight;
+  final Color keyTextColor;
+  final Color keyTextColorNotPressed;
 
   const KeyboardScreen(
       {super.key,
       required this.keyPressStates,
       required this.layout,
-      required this.fontStyle,
-      required this.keyFontSize,
-      required this.spaceFontSize,
-      required this.fontWeight,
-      required this.keyTextColor,
-      required this.keyTextColorNotPressed,
+      required this.showAltLayout,
+      required this.altLayout,
       required this.keyColorPressed,
       required this.keyColorNotPressed,
-      required this.keySize,
-      required this.keyBorderRadius,
-      required this.keyPadding,
       required this.markerColor,
       required this.markerColorNotPressed,
       required this.markerOffset,
       required this.markerWidth,
       required this.markerHeight,
       required this.markerBorderRadius,
-      required this.spaceWidth,
       required this.keymapStyle,
+      required this.showTopRow,
+      required this.keySize,
+      required this.keyBorderRadius,
+      required this.keyPadding,
+      required this.spaceWidth,
       required this.splitWidth,
-      required this.showTopRow});
+      required this.fontStyle,
+      required this.keyFontSize,
+      required this.spaceFontSize,
+      required this.fontWeight,
+      required this.keyTextColor,
+      required this.keyTextColorNotPressed});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -187,14 +187,14 @@ class KeyboardScreen extends StatelessWidget {
     // Tactile Markers
     if (rowIndex == 2 && (keyIndex == 3 || keyIndex == 6)) {
       keyWidget = Stack(
-        alignment: Alignment.bottomCenter,
+        alignment: showAltLayout ? Alignment.center : Alignment.bottomCenter,
         children: [
           keyWidget,
           Positioned(
-            bottom: markerOffset,
+            bottom: showAltLayout ? null : markerOffset,
             child: Container(
-              width: markerWidth,
-              height: markerHeight,
+                width: markerWidth * (showAltLayout ? 0.5 : 1),
+                height: showAltLayout ? markerWidth * 0.5 : markerHeight,
               decoration: BoxDecoration(
                 color: tactMarkerColor,
                 borderRadius: BorderRadius.circular(markerBorderRadius),

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -22,7 +22,6 @@ class KeyboardScreen extends StatelessWidget {
   final double keyPadding;
   final double spaceWidth;
   final double splitWidth;
-  final String fontStyle;
   final double keyFontSize;
   final double spaceFontSize;
   final FontWeight fontWeight;
@@ -50,7 +49,6 @@ class KeyboardScreen extends StatelessWidget {
       required this.keyPadding,
       required this.spaceWidth,
       required this.splitWidth,
-      required this.fontStyle,
       required this.keyFontSize,
       required this.spaceFontSize,
       required this.fontWeight,

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -402,13 +402,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
             }
             _updateMainWindow('updateUseUserLayout', value);
           }),
-          _buildToggleOption('Show alternative layout', _showAltLayout, (value) {
+          _buildToggleOption('Show alternative layout', _showAltLayout,
+              (value) {
             setState(() => _showAltLayout = value);
             _updateMainWindow('updateShowAltLayout', value);
           }),
           _buildToggleOption('Connect to Kanata', _kanataEnabled,
               subtitle:
-                  'Make sure that Kanata and OverKeys are using the same port.',
+                  'Make sure that Kanata and OverKeys are using the same port. Restart OverKeys if config file changes were made to apply changes.',
               (value) {
             if (value && _useUserLayout) {
               // If turning on kanataEnabled, turn off useUserLayout
@@ -837,7 +838,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
                         fontWeight: FontWeight.w600,
                         fontSize: 16)),
                 Text(
-                  'Restart OverKeys to apply any changes made to this file',
+                  'Turn related advanced setting off then on again to apply changes',
                   style: TextStyle(
                       color: colorScheme.onSurface.withAlpha(153),
                       fontSize: 14.0),

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -402,7 +402,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
             }
             _updateMainWindow('updateUseUserLayout', value);
           }),
-          _buildToggleOption('Show alt layout', _showAltLayout, (value) {
+          _buildToggleOption('Show alternative layout', _showAltLayout, (value) {
             setState(() => _showAltLayout = value);
             _updateMainWindow('updateShowAltLayout', value);
           }),
@@ -460,11 +460,17 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           setState(() => _markerOffset = value);
           _updateMainWindow('updateMarkerOffset', value);
         }),
-        _buildSliderOption('Marker width', _markerWidth, 0, 20, 20, (value) {
+        _buildSliderOption('Marker width', _markerWidth, 0, 20, 20,
+            subtitle: _showAltLayout
+                ? 'When alternative layout is shown, marker width appear at half the size (width × 0.5)'
+                : null, (value) {
           setState(() => _markerWidth = value);
           _updateMainWindow('updateMarkerWidth', value);
         }),
-        _buildSliderOption('Marker height', _markerHeight, 0, 10, 10, (value) {
+        _buildSliderOption('Marker height', _markerHeight, 0, 10, 10,
+            subtitle: _showAltLayout
+                ? 'When alternative layout is shown, marker height is not used and instead equals the marker width after computation'
+                : null, (value) {
           setState(() => _markerHeight = value);
           _updateMainWindow('updateMarkerHeight', value);
         }),
@@ -874,7 +880,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
 
   Widget _buildSliderOption(String label, double value, double min, double max,
       int divisions, Function(double) onChanged,
-      {String Function(double)? valueDisplayFormatter}) {
+      {String Function(double)? valueDisplayFormatter, String? subtitle}) {
     final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
     return _buildOptionContainer(
       Column(
@@ -885,6 +891,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
                   color: colorScheme.onSurface,
                   fontWeight: FontWeight.w600,
                   fontSize: 16)),
+          if (subtitle != null)
+            Text(
+              subtitle,
+              style: TextStyle(
+                  color: colorScheme.onSurface.withAlpha(153), fontSize: 14.0),
+              softWrap: true,
+              overflow: TextOverflow.visible,
+            ),
           Slider(
             value: value,
             min: min,

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -206,6 +206,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     await asyncPrefs.setString('layout', _keyboardLayoutName);
     await asyncPrefs.setBool('showAdvancedSettings', _showAdvancedSettings);
     await asyncPrefs.setBool('useUserLayout', _useUserLayout);
+    await asyncPrefs.setBool('showAltLayout', _showAltLayout);
     await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
 
     // Appearance settings

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -59,7 +59,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   double _splitWidth = 100;
 
   // Text settings
-  String _fontStyle = 'GeistMono';
+  String _fontFamily = 'GeistMono';
   double _keyFontSize = 20;
   double _spaceFontSize = 14;
   FontWeight _fontWeight = FontWeight.w600;
@@ -147,7 +147,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     double splitWidth = await asyncPrefs.getDouble('splitWidth') ?? 100;
 
     // Text settings
-    String fontStyle = await asyncPrefs.getString('fontStyle') ?? 'GeistMono';
+    String fontFamily = await asyncPrefs.getString('fontFamily') ?? 'GeistMono';
     double keyFontSize = await asyncPrefs.getDouble('keyFontSize') ?? 20;
     double spaceFontSize = await asyncPrefs.getDouble('spaceFontSize') ?? 14;
     FontWeight fontWeight = FontWeight
@@ -189,7 +189,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _splitWidth = splitWidth;
 
       // Text settings
-      _fontStyle = fontStyle;
+      _fontFamily = fontFamily;
       _keyFontSize = keyFontSize;
       _spaceFontSize = spaceFontSize;
       _fontWeight = fontWeight;
@@ -232,7 +232,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     await asyncPrefs.setDouble('splitWidth', _splitWidth);
 
     // Text settings
-    await asyncPrefs.setString('fontStyle', _fontStyle);
+    await asyncPrefs.setString('fontFamily', _fontFamily);
     await asyncPrefs.setDouble('keyFontSize', _keyFontSize);
     await asyncPrefs.setDouble('spaceFontSize', _spaceFontSize);
     await asyncPrefs.setInt('fontWeight', _fontWeight.index);
@@ -541,7 +541,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildSectionTitle('Text Settings'),
-        _buildDropdownOption('Font style', _fontStyle, [
+        _buildDropdownOption('Font style', _fontFamily, [
           'Berkeley Mono',
           'Cascadia Mono',
           'Comic Mono',
@@ -585,8 +585,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           'Ubuntu Mono',
           'Victor Mono',
         ], (value) {
-          setState(() => _fontStyle = value!);
-          _updateMainWindow('updateFontStyle', value);
+          setState(() => _fontFamily = value!);
+          _updateMainWindow('updateFontFamily', value);
         },
             subtitle:
                 'Make sure that the font is installed in your system. Falls back to Geist Mono'),

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -35,6 +35,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   String _keyboardLayoutName = 'QWERTY';
   bool _showAdvancedSettings = false;
   bool _useUserLayout = false;
+  bool _showAltLayout = false;
   bool _kanataEnabled = false;
 
   // Appearance settings
@@ -115,6 +116,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     bool showAdvancedSettings =
         await asyncPrefs.getBool('showAdvancedSettings') ?? false;
     bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
+    bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
     bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
 
     // Appearance settings
@@ -163,6 +165,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _keyboardLayoutName = keyboardLayoutName;
       _showAdvancedSettings = showAdvancedSettings;
       _useUserLayout = useUserLayout;
+      _showAltLayout = showAltLayout;
       _kanataEnabled = kanataEnabled;
 
       // Appearance settings
@@ -397,6 +400,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
               setState(() => _useUserLayout = value);
             }
             _updateMainWindow('updateUseUserLayout', value);
+          }),
+          _buildToggleOption('Show alt layout', _showAltLayout, (value) {
+            setState(() => _showAltLayout = value);
+            _updateMainWindow('updateShowAltLayout', value);
           }),
           _buildToggleOption('Connect to Kanata', _kanataEnabled,
               subtitle:

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -34,6 +34,12 @@ class ConfigService {
         final contents = await file.readAsString();
         final json = jsonDecode(contents) as Map<String, dynamic>;
         _cachedConfig = UserConfig.fromJson(json);
+        if (kDebugMode) {
+          final configCopy = _cachedConfig!.toJson();
+          configCopy['userLayouts'] =
+              _cachedConfig!.userLayouts.map((layout) => layout.name).toList();
+          print('Config contents: ${jsonEncode(configCopy)}');
+        }
       } else {
         // Create default config if file doesn't exist
         _cachedConfig = UserConfig();
@@ -70,6 +76,7 @@ class ConfigService {
       'port': config.kanataPort,
       'userLayouts': config.userLayouts,
       'defaultUserLayout': config.defaultUserLayout,
+      'altLayout': config.altLayout,
     };
   }
 
@@ -89,6 +96,30 @@ class ConfigService {
     } catch (e) {
       if (kDebugMode) {
         print('Default user layout "$defaultLayoutName" not found');
+      }
+      return null;
+    }
+  }
+
+  Future<KeyboardLayout?> getAltLayout() async {
+    final config = await loadConfig();
+    final altLayoutName = config.altLayout;
+
+    for (final layout in config.userLayouts) {
+      if (layout.name == altLayoutName) {
+        if (kDebugMode) {
+          print('Alt layout found: $altLayoutName');
+        }
+        return layout;
+      }
+    }
+
+    try {
+      return availableLayouts
+          .firstWhere((layout) => layout.name == altLayoutName);
+    } catch (e) {
+      if (kDebugMode) {
+        print('Alt layout "$altLayoutName" not found');
       }
       return null;
     }

--- a/lib/services/kanata_service.dart
+++ b/lib/services/kanata_service.dart
@@ -163,19 +163,6 @@ class KanataService {
     }
   }
 
-  KeyboardLayout? getLayoutByName(String name) {
-    try {
-      return _userLayouts.firstWhere(
-        (layout) => layout.name.toUpperCase() == name.toUpperCase(),
-        orElse: () => throw Exception(),
-      );
-    } catch (_) {
-      return null;
-    }
-  }
-
-  List<KeyboardLayout> get userLayouts => _userLayouts;
-
   void dispose() {
     disconnect();
   }


### PR DESCRIPTION
This pull request adds support for showing another layout together with the default layout. This solves issue #11.

### Major changes:

#### Alternate Keyboard Layout:
* Added new properties `_altLayout` and `_showAltLayout` to manage the alternate keyboard layout in `class _MainAppState` (`lib/app.dart`).
* Implemented `_loadAltLayout` method to load the alternate layout configuration (`lib/app.dart`).
* Updated various methods to handle the alternate layout, including saving and loading preferences (`lib/app.dart`).
* Modified `KeyboardScreen` to display keys from the alternate layout when `_showAltLayout` is true (`lib/screens/keyboard_screen.dart`).

#### Font Style to Font Family:
* Renamed `_fontStyle` to `_fontFamily` across the application to better reflect its use (`lib/app.dart`, `lib/screens/preferences_screen.dart`).

#### User Configuration:
* Added `altLayout` property to `UserConfig` to store the alternate layout configuration (`lib/models/user_config.dart`).

#### Preferences Screen:
* Updated `PreferencesScreen` to include the `showAltLayout` setting (`lib/screens/preferences_screen.dart`).

Russian Demo:
![image](https://github.com/user-attachments/assets/48ffd4a4-0404-4366-8830-4612f394b43f)
Arabic Demo:
![image](https://github.com/user-attachments/assets/5d324b70-f916-4356-8b71-f56b126e85a6)

