### PR TITLE
build: automate versioning in build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Local build and release script
+build.ps1

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
@@ -27,6 +28,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
 
   // UI state
   Brightness _brightness = Brightness.dark;
+  String _appVersion = '';
   String _currentTab = 'General';
 
   // General settings
@@ -75,6 +77,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     _loadPreferences();
     _setupMethodHandler();
     _detectSystemTheme();
+    _loadAppVersion();
   }
 
   void _detectSystemTheme() {
@@ -88,6 +91,15 @@ class _PreferencesScreenState extends State<PreferencesScreen>
         });
       }
     };
+  }
+
+  Future<void> _loadAppVersion() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    if (mounted) {
+      setState(() {
+        _appVersion = packageInfo.version;
+      });
+    }
   }
 
   @override
@@ -737,7 +749,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
                   fontSize: 28,
                   fontWeight: FontWeight.w900)),
           const SizedBox(height: 20),
-          Text('Version: 0.2.3-alpha.1',
+          Text('Version: $_appVersion',
               style: TextStyle(
                   color: colorScheme.onSurface,
                   fontSize: 16,

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -69,7 +69,7 @@ IDI_APP_ICON            ICON                    "resources\\app_icon.ico"
 #if defined(FLUTTER_VERSION)
 #define VERSION_AS_STRING FLUTTER_VERSION
 #else
-#define VERSION_AS_STRING "0.2.3-alpha.1"
+#define VERSION_AS_STRING "1.0.0"
 #endif
 
 VS_VERSION_INFO VERSIONINFO
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "OverKeys" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "OverKeys" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2024 Angelo Convento. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2024 Angelo Convento" "\0"
             VALUE "OriginalFilename", "OverKeys.exe" "\0"
             VALUE "ProductName", "OverKeys" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
This pull request includes updates to the versioning and display of the app version in the preferences screen, as well as minor changes to the Windows resource file. The most important changes include adding functionality to dynamically load and display the app version, and updating the version number and copyright information.

### Versioning and Display Updates:

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R7): Added import for `package_info_plus`, introduced `_appVersion` variable, and created `_loadAppVersion` method to fetch and set the app version dynamically. Updated the version display text to use `_appVersion`. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R7) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R31) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R80) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R96-R104) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L740-R752)

### Windows Resource File Changes:

* [`windows/runner/Runner.rc`](diffhunk://#diff-2d2876a4e095f991fed93440c66432ef0a0a62b7fbdd750d26150fbd77435d0aL72-R72): Updated the version string to "1.0.0" and made a minor change to the copyright line. [[1]](diffhunk://#diff-2d2876a4e095f991fed93440c66432ef0a0a62b7fbdd750d26150fbd77435d0aL72-R72) [[2]](diffhunk://#diff-2d2876a4e095f991fed93440c66432ef0a0a62b7fbdd750d26150fbd77435d0aL96-R96)