### PR TITLE
fix: allow active window to remain in focus

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -603,12 +603,12 @@ class _MainAppState extends State<MainApp> with TrayListener {
       setState(() {
         _isWindowVisible = false;
       });
-      windowManager.hide();
+      windowManager.blur();
     });
   }
 
   void _fadeIn() {
-    windowManager.show().then((_) {
+    windowManager.blur().then((_) {
       setState(() {
         _isWindowVisible = true;
         _opacity = _lastOpacity;

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -29,7 +29,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
   static const double _defaultTopRowExtraHeight = 80;
   static const double _defaultTopRowExtraWidth = 160;
   static const Duration _fadeDuration = Duration(milliseconds: 200);
-  static const Duration _hideDelay = Duration(milliseconds: 300);
 
   // Services
   final SharedPreferencesAsync asyncPrefs = SharedPreferencesAsync();
@@ -598,13 +597,9 @@ class _MainAppState extends State<MainApp> with TrayListener {
     setState(() {
       _lastOpacity = _opacity;
       _opacity = 0.0;
+      _isWindowVisible = false;
     });
-    Timer(_hideDelay, () {
-      setState(() {
-        _isWindowVisible = false;
-      });
-      windowManager.blur();
-    });
+    windowManager.blur();
   }
 
   void _fadeIn() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,6 @@ void main(List<String> args) async {
         await windowManager.setIcon("assets/images/app_icon.ico");
         await windowManager.center();
         await windowManager.setMinimumSize(const Size(828, 621));
-        await windowManager.show();
         await windowManager.focus();
       });
 
@@ -64,7 +63,6 @@ void main(List<String> args) async {
       await windowManager.setSize(Size(windowWidth, windowHeight));
       await windowManager.setIgnoreMouseEvents(true);
       await windowManager.setAlignment(Alignment.bottomCenter);
-      await windowManager.show();
     });
 
     runApp(const MainApp());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ void main(List<String> args) async {
         await windowManager.center();
         await windowManager.setMinimumSize(const Size(828, 621));
         await windowManager.focus();
+        await windowManager.show();
       });
 
       runApp(PreferencesScreen(
@@ -63,6 +64,7 @@ void main(List<String> args) async {
       await windowManager.setSize(Size(windowWidth, windowHeight));
       await windowManager.setIgnoreMouseEvents(true);
       await windowManager.setAlignment(Alignment.bottomCenter);
+      await windowManager.show();
     });
 
     runApp(const MainApp());

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -393,10 +393,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           sizeCurve: Curves.easeInOut,
         ),
         _buildDropdownOption('Layout', _keyboardLayoutName,
-            availableLayouts.map((layout) => (layout.name)).toList(),
-            subtitle: _autoHideEnabled
-                ? 'OverKeys must remain visible to avoid losing focus when typing in the dropdown. You may turn off auto-hide under General settings.'
-                : null, (value) {
+            availableLayouts.map((layout) => (layout.name)).toList(), (value) {
           setState(() => _keyboardLayoutName = value!);
           _updateMainWindow('updateLayout', value);
         }),
@@ -642,7 +639,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           _updateMainWindow('updateFontFamily', value);
         },
             subtitle:
-                'Make sure that the font is installed in your system. Falls back to Geist Mono.${_autoHideEnabled ? ' OverKeys must remain visible to avoid losing focus when typing in the dropdown. You may turn off auto-hide under General settings.' : ''}'),
+                'Make sure that the font is installed in your system. Falls back to Geist Mono.'),
         _buildSliderOption('Key font size', _keyFontSize, 12, 32, 40, (value) {
           setState(() => _keyFontSize = value);
           _updateMainWindow('updateKeyFontSize', value);
@@ -681,10 +678,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
               'Bold',
               'ExtraBold',
               'Black'
-            ],
-            subtitle: _autoHideEnabled
-                ? 'OverKeys must remain visible to avoid losing focus when typing in the dropdown. You may turn off auto-hide under General settings.'
-                : null, (value) {
+            ], (value) {
           setState(() {
             switch (value) {
               case 'Thin':


### PR DESCRIPTION
This pull request includes changes to modifying the window visibility handling, updating the main window interaction, and simplifying the dropdown option handling in the preferences screen. This PR tries to solve bug #30.

Improvements to window visibility handling:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL32): Removed the `_hideDelay` constant and updated the `_fadeOut` and `_fadeIn` methods to use `windowManager.blur()` instead of `windowManager.hide()` and `windowManager.show()`. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL32) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL601-R606)

Updates to main window interaction:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L34-R35): Adjusted the order of `windowManager` methods to ensure `windowManager.show()` is called after `windowManager.focus()`.

Simplifications in preferences screen:

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L396-R396): Removed unnecessary subtitles from `_buildDropdownOption` calls to streamline the user interface. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L396-R396) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L645-R642) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L684-R681)