### PR TITLE
fix: reset keyboard press states on session unlock

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -557,25 +557,39 @@ class _MainAppState extends State<MainApp> with TrayListener {
   }
 
   void _handleKeyEvent(dynamic message) {
+    if (message is! List) return;
+
+    // Session event (session unlock)
+    if (message[0] is String) {
+      if (message[0] == 'session_unlock') {
+        setState(() => _keyPressStates.clear());
+        if (kDebugMode) {
+          print('All key press states cleared due to session unlock');
+        }
+      }
+      return;
+    }
+
+    // Regular key events
     if (message[0] is! int) return;
 
+    int keyCode = message[0];
+    bool isPressed = message[1];
+    bool isShiftDown = message[2];
+    String key = getKeyFromKeyCodeShift(keyCode, isShiftDown);
+
+    if (kDebugMode) {
+      print(
+          'Key: ${key.padRight(10)}\tKeyCode: ${keyCode.toString().padRight(5)}\tPressed: ${isPressed.toString().padRight(5)}\tShift: $isShiftDown');
+    }
     setState(() {
-      int keyCode = message[0];
-      bool isPressed = message[1];
-      bool isShiftDown = message[2];
-
-      if (kDebugMode) {
-        print(
-            'Key: ${getKeyFromKeyCodeShift(keyCode, isShiftDown).padRight(10)}\tKeyCode: ${keyCode.toString().padRight(5)}\tPressed: ${isPressed.toString().padRight(5)}\tShift: $isShiftDown');
-      }
-
-      _keyPressStates[getKeyFromKeyCodeShift(keyCode, isShiftDown)] = isPressed;
-      _resetAutoHideTimer();
-
-      if (_autoHideEnabled && !_isWindowVisible) {
-        _fadeIn();
-      }
+      _keyPressStates[key] = isPressed;
     });
+    if (_autoHideEnabled && !_isWindowVisible && isPressed) {
+      _fadeIn();
+    } else {
+      _resetAutoHideTimer();
+    }
   }
 
   void _resetAutoHideTimer() {

--- a/lib/utils/hooks.dart
+++ b/lib/utils/hooks.dart
@@ -6,7 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'package:win32/win32.dart';
 
 final keyboardProc = Pointer.fromFunction<HOOKPROC>(lowLevelKeyboardProc, 0);
+final sessionProc = Pointer.fromFunction<WNDPROC>(sessionNotificationProc, 0);
 late int hookId;
+late int sessionWindowHandle;
 SendPort? sendPort;
 
 int lowLevelKeyboardProc(
@@ -20,31 +22,16 @@ int lowLevelKeyboardProc(
           wParam == WM_SYSKEYDOWN ||
           wParam == WM_SYSKEYUP)) {
     final keyStruct = Pointer<KBDLLHOOKSTRUCT>.fromAddress(lParam).ref;
-    // if (kDebugMode) {
-    //   print('KBDLLHOOKSTRUCT: {');
-    //   print('  vkCode: ${keyStruct.vkCode},');
-    //   print('  LLKHF_INJECTED: ${(keyStruct.flags & LLKHF_INJECTED) != 0},');
-    //   print('  LLKHF_UP: ${(keyStruct.flags & LLKHF_UP) != 0},');
-    //   print('}');
-    // }
     int keyCode = keyStruct.vkCode;
     bool isPressed = !((keyStruct.flags & LLKHF_UP) != 0);
     bool isShiftDown = GetKeyState(VK_SHIFT) & 0x8000 != 0;
 
-    // Pros: Would fix behavior when OK opened after Kanata
-    // Cons: Would make app non-responsive when not using Kanata
-    // if ((keyStruct.flags & LLKHF_INJECTED) != 0) {
     sendPort?.send([keyCode, isPressed, isShiftDown]);
-    // }
 
-    // For key release events, also send update for shifted variant
-    // Due to Kanata releasing shift key before sending key release event
     if (!isPressed) {
       if (!isShiftDown) {
-        // If shift is not down, send shifted variant
         sendPort?.send([keyCode, false, true]);
       } else {
-        // If shift is down, send non-shifted variant
         sendPort?.send([keyCode, false, false]);
       }
     }
@@ -52,8 +39,74 @@ int lowLevelKeyboardProc(
   return CallNextHookEx(hookId, nCode, wParam, lParam);
 }
 
+int sessionNotificationProc(int hwnd, int message, int wParam, int lParam) {
+  if (message == WM_WTSSESSION_CHANGE) {
+    switch (wParam) {
+      case WTS_SESSION_LOCK:
+        sendPort?.send(['session_lock', true]);
+        break;
+      case WTS_SESSION_UNLOCK:
+        sendPort?.send(['session_unlock', true]);
+        break;
+    }
+  }
+  return DefWindowProc(hwnd, message, wParam, lParam);
+}
+
+void registerSessionNotification(int hwnd) {
+  final result = WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION);
+  if (result == 0) {
+    if (kDebugMode) {
+      print('Failed to register session notification');
+    }
+    exit(1);
+  }
+}
+
+bool unregisterSessionNotification(int hwnd) {
+  return WTSUnRegisterSessionNotification(hwnd) != 0;
+}
+
+int createSessionNotificationWindow() {
+  final wc = calloc<WNDCLASS>();
+  try {
+    wc.ref.lpfnWndProc = sessionProc;
+    wc.ref.hInstance = GetModuleHandle(nullptr);
+    wc.ref.lpszClassName = TEXT('SessionNotificationWindow');
+
+    RegisterClass(wc);
+    final hwnd = CreateWindowEx(
+      0,
+      TEXT('SessionNotificationWindow'),
+      TEXT('Session Notification Window'),
+      0,
+      0,
+      0,
+      0,
+      0,
+      HWND_MESSAGE,
+      NULL,
+      GetModuleHandle(nullptr),
+      nullptr,
+    );
+
+    if (hwnd == 0) {
+      if (kDebugMode) {
+        print('Failed to create notification window: ${GetLastError()}');
+      }
+      exit(1);
+    }
+
+    return hwnd;
+  } finally {
+    calloc.free(wc);
+  }
+}
+
 void setHook(SendPort port) {
   sendPort = port;
+
+  // Set up ke yboard hook
   hookId = SetWindowsHookEx(
       WH_KEYBOARD_LL, keyboardProc, GetModuleHandle(nullptr), 0);
   if (hookId == 0) {
@@ -62,15 +115,26 @@ void setHook(SendPort port) {
     }
     exit(1);
   }
+
+  // Set up session notification window
+  sessionWindowHandle = createSessionNotificationWindow();
+  registerSessionNotification(sessionWindowHandle);
+
   final msg = calloc<MSG>();
-  while (GetMessage(msg, NULL, 0, 0) != 0) {
-    TranslateMessage(msg);
-    DispatchMessage(msg);
-    sendPort?.send(msg);
+  try {
+    while (GetMessage(msg, NULL, 0, 0) != 0) {
+      TranslateMessage(msg);
+      DispatchMessage(msg);
+      sendPort?.send(msg);
+    }
+  } finally {
+    calloc.free(msg);
   }
-  calloc.free(msg);
 }
 
 void unhook() {
   UnhookWindowsHookEx(hookId);
+  unregisterSessionNotification(sessionWindowHandle);
+  DestroyWindow(sessionWindowHandle);
+  UnregisterClass(TEXT('SessionNotificationWindow'), GetModuleHandle(nullptr));
 }


### PR DESCRIPTION
This pull request introduces session event handling and refactors key event processing in the `lib/app.dart` and `lib/utils/hooks.dart` files. This solves issue #33.

Session event handling:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR560-L578): Added handling for session unlock events to clear key press states and reset the auto-hide timer.
* [`lib/utils/hooks.dart`](diffhunk://#diff-61fd13f9561c89c12ec2e0df20f9eb7a0ab07039bf9af7327df8a1818a6858a0L23-R109): Implemented `sessionNotificationProc` to handle session lock and unlock events and send appropriate messages.
* [`lib/utils/hooks.dart`](diffhunk://#diff-61fd13f9561c89c12ec2e0df20f9eb7a0ab07039bf9af7327df8a1818a6858a0R118-R139): Created a session notification window and registered/unregistered session notifications in `setHook` and `unhook` functions.

Key event processing refactor:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR560-L578): Refactored `_handleKeyEvent` to improve readability and maintainability by separating session and regular key event handling.
* [`lib/utils/hooks.dart`](diffhunk://#diff-61fd13f9561c89c12ec2e0df20f9eb7a0ab07039bf9af7327df8a1818a6858a0L23-R109): Cleaned up and simplified the `lowLevelKeyboardProc` function by removing commented-out code and improving the structure.