### PR TITLE
feat: make advanced settings toggle more intuitive/functional

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -100,7 +100,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
     _initStartupSetting();
     await _loadKanataConfig();
     _setupKanataLayerChangeHandler();
-
     // Delayed initialization tasks
     Future.delayed(const Duration(seconds: 2), () {
       if (_useUserLayout) {
@@ -150,14 +149,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
   Future<void> _handleStartupToggle(bool enable) async {
     if (enable) {
       await launchAtStartup.enable();
-      if (kDebugMode) {
-        print('On system startup: Enabled');
-      }
     } else {
       await launchAtStartup.disable();
-      if (kDebugMode) {
-        print('On system startup: Disabled');
-      }
     }
     await _initStartupSetting();
   }
@@ -417,10 +410,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
         case 'updateEnableAdvancedSettings':
           final enableAdvancedSettings = call.arguments as bool;
           setState(() => _enableAdvancedSettings = enableAdvancedSettings);
-          // Check advanced features based on advanced settings toggle state
           if (!enableAdvancedSettings) {
             _previousShowAltLayout = _showAltLayout;
-            // Disconnect kanata service if it was enabled
             if (_kanataEnabled) {
               _kanataService.disconnect();
               if (_initialKeyboardLayout != null) {
@@ -432,8 +423,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
                 }
               }
             }
-
-            // Revert to initial layout if using user layout
             if (_useUserLayout &&
                 !_kanataEnabled &&
                 _initialKeyboardLayout != null) {
@@ -448,17 +437,9 @@ class _MainAppState extends State<MainApp> with TrayListener {
               setState(() {
                 _showAltLayout = false;
               });
-              if (kDebugMode) {
-                print(
-                    'Alt layout display disabled when advanced settings turned off');
-              }
             }
             _fadeIn();
           } else {
-            if (kDebugMode) {
-              print('Advanced settings enabled - features can now be toggled');
-            }
-            // If Kanata was previously enabled but disconnected due to advanced settings being off
             if (_kanataEnabled) {
               _loadKanataConfig().then((_) {
                 _kanataService.connect();
@@ -467,24 +448,17 @@ class _MainAppState extends State<MainApp> with TrayListener {
                 }
               });
             }
-
-            // Load user layout if that option is enabled
             if (_useUserLayout && !_kanataEnabled) {
               _loadUserLayout();
               if (kDebugMode) {
                 print('Loading user layout after enabling advanced settings');
               }
             }
-
-            // Load alt layout if that option is enabled
             if (_previousShowAltLayout) {
               setState(() {
                 _showAltLayout = true;
               });
               _loadAltLayout();
-              if (kDebugMode) {
-                print('Loading alt layout after enabling advanced settings');
-              }
             }
           }
 
@@ -495,7 +469,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
             if (useUserLayout) {
               _loadUserLayout();
             } else {
-              // Revert back to the initial layout when turning off user layout
               setState(() {
                 if (_initialKeyboardLayout != null && !_kanataEnabled) {
                   _keyboardLayout = _initialKeyboardLayout!;
@@ -719,9 +692,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
         checked: !_ignoreMouseEvents,
         onClick: (menuItem) {
           setState(() {
-            if (kDebugMode) {
-              print('Mouse Events Toggled');
-            }
             _ignoreMouseEvents = !_ignoreMouseEvents;
             windowManager.setIgnoreMouseEvents(_ignoreMouseEvents);
             if (!_ignoreMouseEvents) {
@@ -749,9 +719,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
         disabled: !_ignoreMouseEvents,
         onClick: (menuItem) {
           setState(() {
-            if (kDebugMode) {
-              print('Auto Hide Toggled');
-            }
             _autoHideEnabled = !_autoHideEnabled;
             if (_autoHideEnabled) {
               _resetAutoHideTimer();

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -48,9 +48,11 @@ class _MainAppState extends State<MainApp> with TrayListener {
   double _autoHideDuration = 2.0;
   KeyboardLayout _keyboardLayout = qwerty;
   KeyboardLayout? _initialKeyboardLayout;
+  bool _enableAdvancedSettings = false;
   bool _useUserLayout = false;
   KeyboardLayout? _altLayout;
   bool _showAltLayout = false;
+  bool _previousShowAltLayout = false;
   bool _kanataEnabled = false;
 
   // Appearance settings
@@ -240,6 +242,8 @@ class _MainAppState extends State<MainApp> with TrayListener {
         await asyncPrefs.getDouble('autoHideDuration') ?? 2.0;
     String keyboardLayoutName =
         await asyncPrefs.getString('layout') ?? 'QWERTY';
+    bool enableAdvancedSettings =
+        await asyncPrefs.getBool('enableAdvancedSettings') ?? false;
     bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
     bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
     bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
@@ -290,6 +294,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
       _keyboardLayout = availableLayouts
           .firstWhere((layout) => layout.name == keyboardLayoutName);
       _initialKeyboardLayout = _keyboardLayout;
+      _enableAdvancedSettings = enableAdvancedSettings;
       _useUserLayout = useUserLayout;
       _showAltLayout = showAltLayout;
       _altLayout = _keyboardLayout;
@@ -331,6 +336,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
     await asyncPrefs.setDouble('autoHideDuration', _autoHideDuration);
     await asyncPrefs.setString('layout', _initialKeyboardLayout!.name);
+    await asyncPrefs.setBool('enableAdvancedSettings', _enableAdvancedSettings);
     await asyncPrefs.setBool('useUserLayout', _useUserLayout);
     await asyncPrefs.setBool('showAltLayout', _showAltLayout);
     await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
@@ -408,6 +414,80 @@ class _MainAppState extends State<MainApp> with TrayListener {
             }
           });
           _fadeIn();
+        case 'updateEnableAdvancedSettings':
+          final enableAdvancedSettings = call.arguments as bool;
+          setState(() => _enableAdvancedSettings = enableAdvancedSettings);
+          // Check advanced features based on advanced settings toggle state
+          if (!enableAdvancedSettings) {
+            _previousShowAltLayout = _showAltLayout;
+            // Disconnect kanata service if it was enabled
+            if (_kanataEnabled) {
+              _kanataService.disconnect();
+              if (_initialKeyboardLayout != null) {
+                setState(() {
+                  _keyboardLayout = _initialKeyboardLayout!;
+                });
+                if (kDebugMode) {
+                  print('Kanata disconnected and reverted to initial layout');
+                }
+              }
+            }
+
+            // Revert to initial layout if using user layout
+            if (_useUserLayout &&
+                !_kanataEnabled &&
+                _initialKeyboardLayout != null) {
+              setState(() {
+                _keyboardLayout = _initialKeyboardLayout!;
+              });
+              if (kDebugMode) {
+                print('Reverted to initial layout');
+              }
+            }
+            if (_showAltLayout) {
+              setState(() {
+                _showAltLayout = false;
+              });
+              if (kDebugMode) {
+                print(
+                    'Alt layout display disabled when advanced settings turned off');
+              }
+            }
+            _fadeIn();
+          } else {
+            if (kDebugMode) {
+              print('Advanced settings enabled - features can now be toggled');
+            }
+            // If Kanata was previously enabled but disconnected due to advanced settings being off
+            if (_kanataEnabled) {
+              _loadKanataConfig().then((_) {
+                _kanataService.connect();
+                if (kDebugMode) {
+                  print('Reconnected to Kanata service');
+                }
+              });
+            }
+
+            // Load user layout if that option is enabled
+            if (_useUserLayout && !_kanataEnabled) {
+              _loadUserLayout();
+              if (kDebugMode) {
+                print('Loading user layout after enabling advanced settings');
+              }
+            }
+
+            // Load alt layout if that option is enabled
+            if (_previousShowAltLayout) {
+              setState(() {
+                _showAltLayout = true;
+              });
+              _loadAltLayout();
+              if (kDebugMode) {
+                print('Loading alt layout after enabling advanced settings');
+              }
+            }
+          }
+
         case 'updateUseUserLayout':
           final useUserLayout = call.arguments as bool;
           setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,7 +40,6 @@ void main(List<String> args) async {
       ));
     }
   } else {
-    // Main window
     PackageInfo packageInfo = await PackageInfo.fromPlatform();
     launchAtStartup.setup(
       appName: packageInfo.appName,

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -400,7 +400,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
         _buildToggleOption('Turn on advanced settings', _enableAdvancedSettings,
             (value) {
           setState(() => _enableAdvancedSettings = value);
-          _savePreferences();
+          _updateMainWindow('updateEnableAdvancedSettings', value);
         }),
         AnimatedCrossFade(
           duration: const Duration(milliseconds: 300),

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -413,7 +413,6 @@ class _PreferencesScreenState extends State<PreferencesScreen>
                       'Sets layout to user-defined defaultUserLayout. Make sure that the layout is saved in the config file.',
                   (value) {
                 if (value && _kanataEnabled) {
-                  // If turning on useUserLayout, turn off kanataEnabled
                   setState(() {
                     _useUserLayout = value;
                     _kanataEnabled = false;
@@ -434,7 +433,6 @@ class _PreferencesScreenState extends State<PreferencesScreen>
                       'Make sure that Kanata and OverKeys are using the same port. Restart OverKeys if config file changes were made to apply changes.',
                   (value) {
                 if (value && _useUserLayout) {
-                  // If turning on kanataEnabled, turn off useUserLayout
                   setState(() {
                     _kanataEnabled = value;
                     _useUserLayout = false;

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -36,7 +36,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   bool _autoHideEnabled = false;
   double _autoHideDuration = 2.0;
   String _keyboardLayoutName = 'QWERTY';
-  bool _showAdvancedSettings = false;
+  bool _enableAdvancedSettings = false;
   bool _useUserLayout = false;
   bool _showAltLayout = false;
   bool _kanataEnabled = false;
@@ -127,8 +127,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
         await asyncPrefs.getDouble('autoHideDuration') ?? 2.0;
     String keyboardLayoutName =
         await asyncPrefs.getString('layout') ?? 'QWERTY';
-    bool showAdvancedSettings =
-        await asyncPrefs.getBool('showAdvancedSettings') ?? false;
+    bool enableAdvancedSettings =
+        await asyncPrefs.getBool('enableAdvancedSettings') ?? false;
     bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
     bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
     bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
@@ -178,7 +178,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _autoHideEnabled = autoHideEnabled;
       _autoHideDuration = autoHideDuration;
       _keyboardLayoutName = keyboardLayoutName;
-      _showAdvancedSettings = showAdvancedSettings;
+      _enableAdvancedSettings = enableAdvancedSettings;
       _useUserLayout = useUserLayout;
       _showAltLayout = showAltLayout;
       _kanataEnabled = kanataEnabled;
@@ -220,7 +220,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
     await asyncPrefs.setDouble('autoHideDuration', _autoHideDuration);
     await asyncPrefs.setString('layout', _keyboardLayoutName);
-    await asyncPrefs.setBool('showAdvancedSettings', _showAdvancedSettings);
+    await asyncPrefs.setBool('enableAdvancedSettings', _enableAdvancedSettings);
     await asyncPrefs.setBool('useUserLayout', _useUserLayout);
     await asyncPrefs.setBool('showAltLayout', _showAltLayout);
     await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
@@ -397,9 +397,9 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           setState(() => _keyboardLayoutName = value!);
           _updateMainWindow('updateLayout', value);
         }),
-        _buildToggleOption('Show advanced settings', _showAdvancedSettings,
+        _buildToggleOption('Turn on advanced settings', _enableAdvancedSettings,
             (value) {
-          setState(() => _showAdvancedSettings = value);
+          setState(() => _enableAdvancedSettings = value);
           _savePreferences();
         }),
         AnimatedCrossFade(
@@ -448,7 +448,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
               _buildOpenConfigButton(),
             ],
           ),
-          crossFadeState: _showAdvancedSettings
+          crossFadeState: _enableAdvancedSettings
               ? CrossFadeState.showSecond
               : CrossFadeState.showFirst,
           sizeCurve: Curves.easeInOut,

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -18,35 +18,20 @@ class ConfigService {
 
   Future<UserConfig> loadConfig() async {
     if (_cachedConfig != null) {
-      // If config is changed, while app is running, cached config will be returned
-      // User needs to restart the app to get the updated config
       return _cachedConfig!;
     }
 
     try {
       final path = await _configPath;
-      if (kDebugMode) {
-        print('Config path: $path');
-      }
       final file = File(path);
 
       if (await file.exists()) {
         final contents = await file.readAsString();
         final json = jsonDecode(contents) as Map<String, dynamic>;
         _cachedConfig = UserConfig.fromJson(json);
-        if (kDebugMode) {
-          final configCopy = _cachedConfig!.toJson();
-          configCopy['userLayouts'] =
-              _cachedConfig!.userLayouts.map((layout) => layout.name).toList();
-          print('Config contents: ${jsonEncode(configCopy)}');
-        }
       } else {
-        // Create default config if file doesn't exist
         _cachedConfig = UserConfig();
         await saveConfig(_cachedConfig!);
-        if (kDebugMode) {
-          print('Created default config: $path');
-        }
       }
     } catch (e) {
       debugPrint('Error loading config: $e');
@@ -107,9 +92,6 @@ class ConfigService {
 
     for (final layout in config.userLayouts) {
       if (layout.name == altLayoutName) {
-        if (kDebugMode) {
-          print('Alt layout found: $altLayoutName');
-        }
         return layout;
       }
     }

--- a/lib/services/kanata_service.dart
+++ b/lib/services/kanata_service.dart
@@ -46,19 +46,12 @@ class KanataService {
       _port = config.kanataPort;
       _userLayouts = config.userLayouts;
       _defaultUserLayout = config.defaultUserLayout;
-
-      if (kDebugMode) {
-        print(
-            'Connecting to Kanata at $_host:$_port with ${_userLayouts.length} layers. Default layer: $_defaultUserLayout');
-      }
-
       _kanataSocket = await Socket.connect(_host, _port);
       if (kDebugMode) {
         print('Connected to Kanata server at $_host:$_port');
       }
 
       _isConnected = true;
-
       _kanataSocket!.listen(
         (data) {
           String message = String.fromCharCodes(data).trim();
@@ -120,8 +113,8 @@ class KanataService {
               ),
             );
 
-            bool isDefaultUserLayout =
-                newLayout.name.toUpperCase() == _defaultUserLayout.toUpperCase();
+            bool isDefaultUserLayout = newLayout.name.toUpperCase() ==
+                _defaultUserLayout.toUpperCase();
 
             onLayerChange!(newLayout, isDefaultUserLayout);
 

--- a/lib/utils/hooks.dart
+++ b/lib/utils/hooks.dart
@@ -106,7 +106,7 @@ int createSessionNotificationWindow() {
 void setHook(SendPort port) {
   sendPort = port;
 
-  // Set up ke yboard hook
+  // Set up keyboard hook
   hookId = SetWindowsHookEx(
       WH_KEYBOARD_LL, keyboardProc, GetModuleHandle(nullptr), 0);
   if (hookId == 0) {


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable advanced settings in the application, along with various code cleanups and improvements. The most important changes include adding the `enableAdvancedSettings` variable, updating the preferences screen to reflect this new setting, and removing debug print statements across multiple files.

### New Feature: Advanced Settings

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR51-R55): Added `enableAdvancedSettings` and `previousShowAltLayout` variables, and updated related methods to handle the new setting. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR51-R55) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR238-R239) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR290) [[4]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR332) [[5]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR410-L418)
* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L39-R39): Replaced `showAdvancedSettings` with `enableAdvancedSettings` and updated the preferences screen to handle this new setting. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L39-R39) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L130-R131) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L181-R181) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L223-R223) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L400-R403) [[6]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5L451-R449)

### Code Cleanup

* Removed unnecessary debug print statements from various files to clean up the codebase. [[1]](diffhunk://#diff-be501a27823df26bd865c669f7738eba96906f3c7a1dce03bf014b426f7dbf31L21-L49) [[2]](diffhunk://#diff-be501a27823df26bd865c669f7738eba96906f3c7a1dce03bf014b426f7dbf31L110-L112) [[3]](diffhunk://#diff-8d025c341f6981a06331df91941bd0d3f7514ed9e95384c12e301fc2028b6919L49-L61) [[4]](diffhunk://#diff-8d025c341f6981a06331df91941bd0d3f7514ed9e95384c12e301fc2028b6919L123-R117)

### Minor Improvements

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L43): Removed an unnecessary comment in the main function.
* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL151-L158): Removed redundant debug print statements in the `_handleStartupToggle` method and other parts of the file. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL151-L158) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL642-L644) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL672-L674)