### PR TITLE
refactor: restructure preferences services and screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -100,16 +100,17 @@ class _MainAppState extends State<MainApp> with TrayListener {
     _initStartupSetting();
     await _loadKanataConfig();
     _setupKanataLayerChangeHandler();
-    // Delayed initialization tasks
     Future.delayed(const Duration(seconds: 2), () {
-      if (_useUserLayout) {
-        _loadUserLayout();
-      }
-      if (_showAltLayout) {
-        _loadAltLayout();
-      }
-      if (_kanataEnabled) {
-        _kanataService.connect();
+      if (_enableAdvancedSettings) {
+        if (_useUserLayout) {
+          _loadUserLayout();
+        }
+        if (_showAltLayout) {
+          _loadAltLayout();
+        }
+        if (_kanataEnabled) {
+          _kanataService.connect();
+        }
       }
       if (_showTopRow) {
         _adjustWindowSize();

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -251,7 +251,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
     final configService = ConfigService();
     final config = await configService.loadConfig();
 
-    if (_kanataEnabled) {
+    if (_kanataEnabled && _enableAdvancedSettings) {
       _kanataService.updateSettings(
           config.kanataHost, config.kanataPort, config.userLayouts);
 
@@ -633,7 +633,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
                 print('Loading user layout after enabling advanced settings');
               }
             }
-            if (_previousShowAltLayout) {
+            if (_previousShowAltLayout || _showAltLayout) {
               setState(() {
                 _showAltLayout = true;
               });

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -798,7 +798,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
                   child: KeyboardScreen(
                     keyPressStates: _keyPressStates,
                     layout: _keyboardLayout,
-                    showAltLayout: _showAltLayout,
+                    showAltLayout: _enableAdvancedSettings && _showAltLayout,
                     altLayout: _altLayout,
                     keyColorPressed: _keyColorPressed,
                     keyColorNotPressed: _keyColorNotPressed,

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -576,7 +576,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
         case 'updateLayout':
           final layoutName = call.arguments as String;
           setState(() {
-            if (_kanataEnabled) {
+            if ((_kanataEnabled || _useUserLayout) && _enableAdvancedSettings) {
               _initialKeyboardLayout = availableLayouts
                   .firstWhere((layout) => layout.name == layoutName);
             } else {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -115,6 +115,9 @@ class _MainAppState extends State<MainApp> with TrayListener {
       if (_showTopRow) {
         _adjustWindowSize();
       }
+      if (_autoHideEnabled) {
+        _resetAutoHideTimer();
+      }
     });
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,11 +6,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:launch_at_startup/launch_at_startup.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:overkeys/services/config_service.dart';
 import 'package:overkeys/services/kanata_service.dart';
+import 'package:overkeys/services/preferences_service.dart';
 import 'package:overkeys/utils/key_code.dart';
 import 'models/keyboard_layouts.dart';
 import 'screens/keyboard_screen.dart';
@@ -31,7 +31,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
   static const Duration _fadeDuration = Duration(milliseconds: 200);
 
   // Services
-  final SharedPreferencesAsync asyncPrefs = SharedPreferencesAsync();
+  final PreferencesService _prefsService = PreferencesService();
   final KanataService _kanataService = KanataService();
   final Map<String, bool> _keyPressStates = {};
 
@@ -92,7 +92,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
   }
 
   Future<void> _initialize() async {
-    await _loadPreferences();
+    await _loadAllPreferences();
     trayManager.addListener(this);
     _setupTray();
     _setupKeyListener();
@@ -117,6 +117,111 @@ class _MainAppState extends State<MainApp> with TrayListener {
     });
   }
 
+  @override
+  void dispose() {
+    trayManager.removeListener(this);
+    unhook();
+    _autoHideTimer?.cancel();
+    _kanataService.dispose();
+    _saveAllPreferences();
+    super.dispose();
+  }
+
+  // Preference handling methods
+  Future<void> _loadAllPreferences() async {
+    // Load all preferences at once
+    final prefs = await _prefsService.loadAllPreferences();
+
+    setState(() {
+      // General settings
+      _autoHideEnabled = prefs['autoHideEnabled'];
+      _autoHideDuration = prefs['autoHideDuration'];
+      _keyboardLayout = availableLayouts
+          .firstWhere((layout) => layout.name == prefs['keyboardLayoutName']);
+      _initialKeyboardLayout = _keyboardLayout;
+      _enableAdvancedSettings = prefs['enableAdvancedSettings'];
+      _useUserLayout = prefs['useUserLayout'];
+      _showAltLayout = prefs['showAltLayout'];
+      _altLayout = _keyboardLayout;
+      _kanataEnabled = prefs['kanataEnabled'];
+
+      // Appearance settings
+      _opacity = prefs['opacity'];
+      _keyColorPressed = prefs['keyColorPressed'];
+      _keyColorNotPressed = prefs['keyColorNotPressed'];
+      _markerColor = prefs['markerColor'];
+      _markerColorNotPressed = prefs['markerColorNotPressed'];
+      _markerOffset = prefs['markerOffset'];
+      _markerWidth = prefs['markerWidth'];
+      _markerHeight = prefs['markerHeight'];
+      _markerBorderRadius = prefs['markerBorderRadius'];
+
+      // Keyboard settings
+      _keymapStyle = prefs['keymapStyle'];
+      _showTopRow = prefs['showTopRow'];
+      _showGraveKey = prefs['showGraveKey'];
+      _keySize = prefs['keySize'];
+      _keyBorderRadius = prefs['keyBorderRadius'];
+      _keyPadding = prefs['keyPadding'];
+      _spaceWidth = prefs['spaceWidth'];
+      _splitWidth = prefs['splitWidth'];
+
+      // Text settings
+      _fontFamily = prefs['fontFamily'];
+      _keyFontSize = prefs['keyFontSize'];
+      _spaceFontSize = prefs['spaceFontSize'];
+      _fontWeight = prefs['fontWeight'];
+      _keyTextColor = prefs['keyTextColor'];
+      _keyTextColorNotPressed = prefs['keyTextColorNotPressed'];
+    });
+  }
+
+  Future<void> _saveAllPreferences() async {
+    final prefs = {
+      // General settings
+      'launchAtStartup': _launchAtStartup,
+      'autoHideEnabled': _autoHideEnabled,
+      'autoHideDuration': _autoHideDuration,
+      'keyboardLayoutName': _initialKeyboardLayout!.name,
+      'enableAdvancedSettings': _enableAdvancedSettings,
+      'useUserLayout': _useUserLayout,
+      'showAltLayout': _showAltLayout,
+      'kanataEnabled': _kanataEnabled,
+
+      // Appearance settings
+      'opacity': _opacity,
+      'keyColorPressed': _keyColorPressed,
+      'keyColorNotPressed': _keyColorNotPressed,
+      'markerColor': _markerColor,
+      'markerColorNotPressed': _markerColorNotPressed,
+      'markerOffset': _markerOffset,
+      'markerWidth': _markerWidth,
+      'markerHeight': _markerHeight,
+      'markerBorderRadius': _markerBorderRadius,
+
+      // Keyboard settings
+      'keymapStyle': _keymapStyle,
+      'showTopRow': _showTopRow,
+      'showGraveKey': _showGraveKey,
+      'keySize': _keySize,
+      'keyBorderRadius': _keyBorderRadius,
+      'keyPadding': _keyPadding,
+      'spaceWidth': _spaceWidth,
+      'splitWidth': _splitWidth,
+
+      // Text settings
+      'fontFamily': _fontFamily,
+      'keyFontSize': _keyFontSize,
+      'spaceFontSize': _spaceFontSize,
+      'fontWeight': _fontWeight,
+      'keyTextColor': _keyTextColor,
+      'keyTextColorNotPressed': _keyTextColorNotPressed,
+    };
+
+    await _prefsService.saveAllPreferences(prefs);
+  }
+
+  // Kanata service related methods
   void _setupKanataLayerChangeHandler() {
     _kanataService.onLayerChange = (newLayout, isDefaultUserLayout) {
       setState(() {
@@ -141,20 +246,24 @@ class _MainAppState extends State<MainApp> with TrayListener {
     }
   }
 
-  Future<void> _initStartupSetting() async {
-    _launchAtStartup = await launchAtStartup.isEnabled();
-    setState(() {});
-  }
+  Future<void> _loadKanataConfig() async {
+    final configService = ConfigService();
+    final config = await configService.loadConfig();
 
-  Future<void> _handleStartupToggle(bool enable) async {
-    if (enable) {
-      await launchAtStartup.enable();
-    } else {
-      await launchAtStartup.disable();
+    if (_kanataEnabled) {
+      _kanataService.updateSettings(
+          config.kanataHost, config.kanataPort, config.userLayouts);
+
+      final defaultLayout = await configService.getUserLayout();
+      setState(() {
+        if (defaultLayout != null) {
+          _keyboardLayout = defaultLayout;
+        }
+      });
     }
-    await _initStartupSetting();
   }
 
+  // Keyboard layout methods
   Future<void> _loadUserLayout() async {
     if (!_useUserLayout) return;
 
@@ -189,23 +298,22 @@ class _MainAppState extends State<MainApp> with TrayListener {
     }
   }
 
-  Future<void> _loadKanataConfig() async {
-    final configService = ConfigService();
-    final config = await configService.loadConfig();
-
-    if (_kanataEnabled) {
-      _kanataService.updateSettings(
-          config.kanataHost, config.kanataPort, config.userLayouts);
-
-      final defaultLayout = await configService.getUserLayout();
-      setState(() {
-        if (defaultLayout != null) {
-          _keyboardLayout = defaultLayout;
-        }
-      });
-    }
+  // Startup related methods
+  Future<void> _initStartupSetting() async {
+    _launchAtStartup = await launchAtStartup.isEnabled();
+    setState(() {});
   }
 
+  Future<void> _handleStartupToggle(bool enable) async {
+    if (enable) {
+      await launchAtStartup.enable();
+    } else {
+      await launchAtStartup.disable();
+    }
+    await _initStartupSetting();
+  }
+
+  // Window management methods
   Future<void> _adjustWindowSize() async {
     _fadeIn();
     double height = _showTopRow
@@ -218,164 +326,234 @@ class _MainAppState extends State<MainApp> with TrayListener {
     await windowManager.setAlignment(Alignment.bottomCenter);
   }
 
-  @override
-  void dispose() {
-    trayManager.removeListener(this);
-    unhook();
-    _autoHideTimer?.cancel();
-    _kanataService.dispose();
-    _savePreferences();
-    super.dispose();
-  }
-
-  Future<void> _loadPreferences() async {
-    // General settings
-    bool autoHideEnabled = await asyncPrefs.getBool('autoHideEnabled') ?? false;
-    double autoHideDuration =
-        await asyncPrefs.getDouble('autoHideDuration') ?? 2.0;
-    String keyboardLayoutName =
-        await asyncPrefs.getString('layout') ?? 'QWERTY';
-    bool enableAdvancedSettings =
-        await asyncPrefs.getBool('enableAdvancedSettings') ?? false;
-    bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
-    bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
-    bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
-
-    // Appearance settings
-    double opacity = await asyncPrefs.getDouble('opacity') ?? 0.6;
-    Color keyColorPressed =
-        Color(await asyncPrefs.getInt('keyColorPressed') ?? 0xFF1E1E1E);
-    Color keyColorNotPressed =
-        Color(await asyncPrefs.getInt('keyColorNotPressed') ?? 0xFF77ABFF);
-    Color markerColor =
-        Color(await asyncPrefs.getInt('markerColor') ?? 0xFFFFFFFF);
-    Color markerColorNotPressed =
-        Color(await asyncPrefs.getInt('markerColorNotPressed') ?? 0xFF000000);
-    double markerOffset = await asyncPrefs.getDouble('markerOffset') ?? 10;
-    double markerWidth = await asyncPrefs.getDouble('markerWidth') ?? 10;
-    double markerHeight = await asyncPrefs.getDouble('markerHeight') ?? 2;
-    double markerBorderRadius =
-        await asyncPrefs.getDouble('markerBorderRadius') ?? 10;
-
-    // Keyboard settings
-    String keymapStyle =
-        await asyncPrefs.getString('keymapStyle') ?? 'Staggered';
-    bool showTopRow = await asyncPrefs.getBool('showTopRow') ?? false;
-    bool showGraveKey = await asyncPrefs.getBool('showGraveKey') ?? false;
-    double keySize = await asyncPrefs.getDouble('keySize') ?? 48;
-    double keyBorderRadius =
-        await asyncPrefs.getDouble('keyBorderRadius') ?? 12;
-    double keyPadding = await asyncPrefs.getDouble('keyPadding') ?? 3;
-    double spaceWidth = await asyncPrefs.getDouble('spaceWidth') ?? 320;
-    double splitWidth = await asyncPrefs.getDouble('splitWidth') ?? 100;
-
-    // Text settings
-    String fontFamily = await asyncPrefs.getString('fontFamily') ?? 'GeistMono';
-    double keyFontSize = await asyncPrefs.getDouble('keyFontSize') ?? 20;
-    double spaceFontSize = await asyncPrefs.getDouble('spaceFontSize') ?? 14;
-    FontWeight fontWeight = FontWeight
-        .values[await asyncPrefs.getInt('fontWeight') ?? FontWeight.w600.index];
-    Color keyTextColor =
-        Color(await asyncPrefs.getInt('keyTextColor') ?? 0xFFFFFFFF);
-    Color keyTextColorNotPressed =
-        Color(await asyncPrefs.getInt('keyTextColorNotPressed') ?? 0xFF000000);
-
+  void _fadeOut() {
     setState(() {
-      // General settings
-      _autoHideEnabled = autoHideEnabled;
-      _autoHideDuration = autoHideDuration;
-      _keyboardLayout = availableLayouts
-          .firstWhere((layout) => layout.name == keyboardLayoutName);
-      _initialKeyboardLayout = _keyboardLayout;
-      _enableAdvancedSettings = enableAdvancedSettings;
-      _useUserLayout = useUserLayout;
-      _showAltLayout = showAltLayout;
-      _altLayout = _keyboardLayout;
-      _kanataEnabled = kanataEnabled;
-
-      // Appearance settings
-      _opacity = opacity;
-      _keyColorPressed = keyColorPressed;
-      _keyColorNotPressed = keyColorNotPressed;
-      _markerColor = markerColor;
-      _markerColorNotPressed = markerColorNotPressed;
-      _markerOffset = markerOffset;
-      _markerWidth = markerWidth;
-      _markerHeight = markerHeight;
-      _markerBorderRadius = markerBorderRadius;
-
-      // Keyboard settings
-      _keymapStyle = keymapStyle;
-      _showTopRow = showTopRow;
-      _showGraveKey = showGraveKey;
-      _keySize = keySize;
-      _keyBorderRadius = keyBorderRadius;
-      _keyPadding = keyPadding;
-      _spaceWidth = spaceWidth;
-      _splitWidth = splitWidth;
-
-      // Text settings
-      _fontFamily = fontFamily;
-      _keyFontSize = keyFontSize;
-      _spaceFontSize = spaceFontSize;
-      _fontWeight = fontWeight;
-      _keyTextColor = keyTextColor;
-      _keyTextColorNotPressed = keyTextColorNotPressed;
+      _lastOpacity = _opacity;
+      _opacity = 0.0;
+      _isWindowVisible = false;
     });
+    windowManager.blur();
   }
 
-  Future<void> _savePreferences() async {
-    // General settings
-    await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
-    await asyncPrefs.setDouble('autoHideDuration', _autoHideDuration);
-    await asyncPrefs.setString('layout', _initialKeyboardLayout!.name);
-    await asyncPrefs.setBool('enableAdvancedSettings', _enableAdvancedSettings);
-    await asyncPrefs.setBool('useUserLayout', _useUserLayout);
-    await asyncPrefs.setBool('showAltLayout', _showAltLayout);
-    await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
-
-    // Appearance settings
-    await asyncPrefs.setDouble('opacity', _opacity);
-    await asyncPrefs.setInt('keyColorPressed', _keyColorPressed.toARGB32());
-    await asyncPrefs.setInt(
-        'keyColorNotPressed', _keyColorNotPressed.toARGB32());
-    await asyncPrefs.setInt('markerColor', _markerColor.toARGB32());
-    await asyncPrefs.setInt(
-        'markerColorNotPressed', _markerColorNotPressed.toARGB32());
-    await asyncPrefs.setDouble('markerOffset', _markerOffset);
-    await asyncPrefs.setDouble('markerWidth', _markerWidth);
-    await asyncPrefs.setDouble('markerHeight', _markerHeight);
-    await asyncPrefs.setDouble('markerBorderRadius', _markerBorderRadius);
-
-    // Keyboard settings
-    await asyncPrefs.setString('keymapStyle', _keymapStyle);
-    await asyncPrefs.setBool('showTopRow', _showTopRow);
-    await asyncPrefs.setBool('showGraveKey', _showGraveKey);
-    await asyncPrefs.setDouble('keySize', _keySize);
-    await asyncPrefs.setDouble('keyBorderRadius', _keyBorderRadius);
-    await asyncPrefs.setDouble('keyPadding', _keyPadding);
-    await asyncPrefs.setDouble('spaceWidth', _spaceWidth);
-    await asyncPrefs.setDouble('splitWidth', _splitWidth);
-
-    // Text settings
-    await asyncPrefs.setString('fontFamily', _fontFamily);
-    await asyncPrefs.setDouble('keyFontSize', _keyFontSize);
-    await asyncPrefs.setDouble('spaceFontSize', _spaceFontSize);
-    await asyncPrefs.setInt('fontWeight', _fontWeight.index);
-    await asyncPrefs.setInt('keyTextColor', _keyTextColor.toARGB32());
-    await asyncPrefs.setInt(
-        'keyTextColorNotPressed', _keyTextColorNotPressed.toARGB32());
+  void _fadeIn() {
+    windowManager.blur().then((_) {
+      setState(() {
+        _isWindowVisible = true;
+        _opacity = _lastOpacity;
+      });
+    });
+    _resetAutoHideTimer();
   }
 
+  // Key handling and auto-hide methods
+  void _setupKeyListener() {
+    ReceivePort receivePort = ReceivePort();
+    Isolate.spawn(setHook, receivePort.sendPort)
+        .then((_) {})
+        .catchError((error) {
+      if (kDebugMode) {
+        print('Error spawning Isolate: $error');
+      }
+    });
+
+    receivePort.listen(_handleKeyEvent);
+  }
+
+  void _handleKeyEvent(dynamic message) {
+    if (message is! List) return;
+
+    // Session event (session unlock)
+    if (message[0] is String) {
+      if (message[0] == 'session_unlock') {
+        setState(() => _keyPressStates.clear());
+        if (kDebugMode) {
+          print('All key press states cleared due to session unlock');
+        }
+      }
+      return;
+    }
+
+    // Regular key events
+    if (message[0] is! int) return;
+
+    int keyCode = message[0];
+    bool isPressed = message[1];
+    bool isShiftDown = message[2];
+    String key = getKeyFromKeyCodeShift(keyCode, isShiftDown);
+
+    if (kDebugMode) {
+      print(
+          'Key: ${key.padRight(10)}\tKeyCode: ${keyCode.toString().padRight(5)}\tPressed: ${isPressed.toString().padRight(5)}\tShift: $isShiftDown');
+    }
+    setState(() {
+      _keyPressStates[key] = isPressed;
+    });
+    if (_autoHideEnabled && !_isWindowVisible && isPressed) {
+      _fadeIn();
+    } else {
+      _resetAutoHideTimer();
+    }
+  }
+
+  void _resetAutoHideTimer() {
+    _autoHideTimer?.cancel();
+    if (_autoHideEnabled) {
+      _autoHideTimer = Timer(
+          Duration(milliseconds: (_autoHideDuration * 1000).round()),
+          _handleAutoHide);
+    }
+  }
+
+  void _handleAutoHide() {
+    if (_autoHideEnabled && _isWindowVisible) {
+      _fadeOut();
+    }
+  }
+
+  // System tray methods
+  Future<void> _setupTray() async {
+    String iconPath = Platform.isWindows
+        ? 'assets/images/app_icon.ico'
+        : 'assets/images/app_icon.png';
+    await trayManager.setIcon(iconPath);
+    trayManager.setToolTip('OverKeys');
+    trayManager.setContextMenu(Menu(items: [
+      MenuItem.checkbox(
+        key: 'toggle_mouse_events',
+        label: 'Move',
+        checked: !_ignoreMouseEvents,
+        onClick: (menuItem) {
+          setState(() {
+            _ignoreMouseEvents = !_ignoreMouseEvents;
+            windowManager.setIgnoreMouseEvents(_ignoreMouseEvents);
+            if (!_ignoreMouseEvents) {
+              autoHideBeforeMove = _autoHideEnabled;
+              _autoHideEnabled = false;
+              _autoHideTimer?.cancel();
+              if (!_isWindowVisible) {
+                _fadeIn();
+              }
+            } else {
+              _autoHideEnabled = autoHideBeforeMove;
+              if (_autoHideEnabled) {
+                _resetAutoHideTimer();
+              }
+            }
+          });
+          _fadeIn();
+        },
+      ),
+      MenuItem.separator(),
+      MenuItem.checkbox(
+        key: 'toggle_auto_hide',
+        label: 'Auto Hide',
+        checked: _autoHideEnabled,
+        disabled: !_ignoreMouseEvents,
+        onClick: (menuItem) {
+          setState(() {
+            _autoHideEnabled = !_autoHideEnabled;
+            if (_autoHideEnabled) {
+              _resetAutoHideTimer();
+            } else {
+              _autoHideTimer?.cancel();
+              if (!_isWindowVisible) {
+                _fadeIn();
+              }
+            }
+          });
+        },
+      ),
+      MenuItem.separator(),
+      MenuItem(
+          key: 'reset_position',
+          label: 'Reset Position',
+          onClick: (menuItem) {
+            windowManager.setAlignment(Alignment.bottomCenter);
+          }),
+      MenuItem.separator(),
+      MenuItem(
+        key: 'preferences',
+        label: 'Preferences',
+        onClick: (menuItem) {
+          if (kDebugMode) {
+            print('Preferences Window Opened');
+          }
+          _showPreferences();
+        },
+      ),
+      MenuItem.separator(),
+      MenuItem(
+        key: 'exit',
+        label: 'Exit',
+      ),
+    ]));
+  }
+
+  @override
+  void onTrayMenuItemClick(MenuItem menuItem) {
+    if (menuItem.key == 'toggle_auto_hide') {
+      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
+        for (final id in windowIds) {
+          DesktopMultiWindow.invokeMethod(
+              id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
+        }
+      });
+    } else if (menuItem.key == 'exit') {
+      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) async {
+        for (final id in windowIds) {
+          await WindowController.fromWindowId(id).close();
+        }
+        await windowManager.close();
+        exit(0);
+      }).catchError((error) {
+        if (kDebugMode) {
+          print('Error closing windows: $error');
+        }
+        windowManager.close();
+        exit(0);
+      });
+      return;
+    }
+    _setupTray();
+  }
+
+  @override
+  void onTrayIconMouseDown() {
+    if (_isWindowVisible) {
+      _fadeOut();
+    } else {
+      _fadeIn();
+    }
+  }
+
+  @override
+  void onTrayIconRightMouseDown() {
+    trayManager.popUpContextMenu();
+  }
+
+  // UI related methods
+  Future<void> _showPreferences() async {
+    try {
+      await DesktopMultiWindow.createWindow(jsonEncode({
+        'name': 'preferences',
+      }));
+    } catch (e) {
+      if (kDebugMode) {
+        print('Error creating preferences window: $e');
+      }
+    }
+  }
+
+  // Method handler for inter-window communication
   void _setupMethodHandler() {
     DesktopMultiWindow.setMethodHandler((call, fromWindowId) async {
       switch (call.method) {
         // General settings
         case 'updateLaunchAtStartup':
-          final launchAtStartupRet = call.arguments as bool;
+          final launchAtStartupValue = call.arguments as bool;
           setState(() {
-            _launchAtStartup = launchAtStartupRet;
-            _handleStartupToggle(launchAtStartupRet);
+            _launchAtStartup = launchAtStartupValue;
+            _handleStartupToggle(launchAtStartupValue);
           });
         case 'updateAutoHideEnabled':
           final autoHideEnabled = call.arguments as bool;
@@ -594,221 +772,6 @@ class _MainAppState extends State<MainApp> with TrayListener {
       }
       return null;
     });
-  }
-
-  void _setupKeyListener() {
-    ReceivePort receivePort = ReceivePort();
-    Isolate.spawn(setHook, receivePort.sendPort)
-        .then((_) {})
-        .catchError((error) {
-      if (kDebugMode) {
-        print('Error spawning Isolate: $error');
-      }
-    });
-
-    receivePort.listen(_handleKeyEvent);
-  }
-
-  void _handleKeyEvent(dynamic message) {
-    if (message is! List) return;
-
-    // Session event (session unlock)
-    if (message[0] is String) {
-      if (message[0] == 'session_unlock') {
-        setState(() => _keyPressStates.clear());
-        if (kDebugMode) {
-          print('All key press states cleared due to session unlock');
-        }
-      }
-      return;
-    }
-
-    // Regular key events
-    if (message[0] is! int) return;
-
-    int keyCode = message[0];
-    bool isPressed = message[1];
-    bool isShiftDown = message[2];
-    String key = getKeyFromKeyCodeShift(keyCode, isShiftDown);
-
-    if (kDebugMode) {
-      print(
-          'Key: ${key.padRight(10)}\tKeyCode: ${keyCode.toString().padRight(5)}\tPressed: ${isPressed.toString().padRight(5)}\tShift: $isShiftDown');
-    }
-    setState(() {
-      _keyPressStates[key] = isPressed;
-    });
-    if (_autoHideEnabled && !_isWindowVisible && isPressed) {
-      _fadeIn();
-    } else {
-      _resetAutoHideTimer();
-    }
-  }
-
-  void _resetAutoHideTimer() {
-    _autoHideTimer?.cancel();
-    if (_autoHideEnabled) {
-      _autoHideTimer = Timer(
-          Duration(milliseconds: (_autoHideDuration * 1000).round()),
-          _handleAutoHide);
-    }
-  }
-
-  void _handleAutoHide() {
-    if (_autoHideEnabled && _isWindowVisible) {
-      _fadeOut();
-    }
-  }
-
-  void _fadeOut() {
-    setState(() {
-      _lastOpacity = _opacity;
-      _opacity = 0.0;
-      _isWindowVisible = false;
-    });
-    windowManager.blur();
-  }
-
-  void _fadeIn() {
-    windowManager.blur().then((_) {
-      setState(() {
-        _isWindowVisible = true;
-        _opacity = _lastOpacity;
-      });
-    });
-    _resetAutoHideTimer();
-  }
-
-  Future<void> _setupTray() async {
-    String iconPath = Platform.isWindows
-        ? 'assets/images/app_icon.ico'
-        : 'assets/images/app_icon.png';
-    await trayManager.setIcon(iconPath);
-    trayManager.setToolTip('OverKeys');
-    trayManager.setContextMenu(Menu(items: [
-      MenuItem.checkbox(
-        key: 'toggle_mouse_events',
-        label: 'Move',
-        checked: !_ignoreMouseEvents,
-        onClick: (menuItem) {
-          setState(() {
-            _ignoreMouseEvents = !_ignoreMouseEvents;
-            windowManager.setIgnoreMouseEvents(_ignoreMouseEvents);
-            if (!_ignoreMouseEvents) {
-              autoHideBeforeMove = _autoHideEnabled;
-              _autoHideEnabled = false;
-              _autoHideTimer?.cancel();
-              if (!_isWindowVisible) {
-                _fadeIn();
-              }
-            } else {
-              _autoHideEnabled = autoHideBeforeMove;
-              if (_autoHideEnabled) {
-                _resetAutoHideTimer();
-              }
-            }
-          });
-          _fadeIn();
-        },
-      ),
-      MenuItem.separator(),
-      MenuItem.checkbox(
-        key: 'toggle_auto_hide',
-        label: 'Auto Hide',
-        checked: _autoHideEnabled,
-        disabled: !_ignoreMouseEvents,
-        onClick: (menuItem) {
-          setState(() {
-            _autoHideEnabled = !_autoHideEnabled;
-            if (_autoHideEnabled) {
-              _resetAutoHideTimer();
-            } else {
-              _autoHideTimer?.cancel();
-              if (!_isWindowVisible) {
-                _fadeIn();
-              }
-            }
-          });
-        },
-      ),
-      MenuItem.separator(),
-      MenuItem(
-          key: 'reset_position',
-          label: 'Reset Position',
-          onClick: (menuItem) {
-            windowManager.setAlignment(Alignment.bottomCenter);
-          }),
-      MenuItem.separator(),
-      MenuItem(
-        key: 'preferences',
-        label: 'Preferences',
-        onClick: (menuItem) {
-          if (kDebugMode) {
-            print('Preferences Window Opened');
-          }
-          _showPreferences();
-        },
-      ),
-      MenuItem.separator(),
-      MenuItem(
-        key: 'exit',
-        label: 'Exit',
-      ),
-    ]));
-  }
-
-  @override
-  void onTrayMenuItemClick(MenuItem menuItem) {
-    if (menuItem.key == 'toggle_auto_hide') {
-      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
-        for (final id in windowIds) {
-          DesktopMultiWindow.invokeMethod(
-              id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
-        }
-      });
-    } else if (menuItem.key == 'exit') {
-      DesktopMultiWindow.getAllSubWindowIds().then((windowIds) async {
-        for (final id in windowIds) {
-          await WindowController.fromWindowId(id).close();
-        }
-        await windowManager.close();
-        exit(0);
-      }).catchError((error) {
-        if (kDebugMode) {
-          print('Error closing windows: $error');
-        }
-        windowManager.close();
-        exit(0);
-      });
-      return;
-    }
-    _setupTray();
-  }
-
-  @override
-  void onTrayIconMouseDown() {
-    if (_isWindowVisible) {
-      _fadeOut();
-    } else {
-      _fadeIn();
-    }
-  }
-
-  @override
-  void onTrayIconRightMouseDown() {
-    trayManager.popUpContextMenu();
-  }
-
-  Future<void> _showPreferences() async {
-    try {
-      await DesktopMultiWindow.createWindow(jsonEncode({
-        'name': 'preferences',
-      }));
-    } catch (e) {
-      if (kDebugMode) {
-        print('Error creating preferences window: $e');
-      }
-    }
   }
 
   @override

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -1,17 +1,16 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
-import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:overkeys/models/user_config.dart';
-import 'package:overkeys/models/keyboard_layouts.dart';
 import 'package:overkeys/utils/theme_manager.dart';
-import 'package:overkeys/services/config_service.dart';
+import 'package:overkeys/services/preferences_service.dart';
+import 'package:overkeys/widgets/preferences/general_tab.dart';
+import 'package:overkeys/widgets/preferences/appearance_tab.dart';
+import 'package:overkeys/widgets/preferences/keyboard_tab.dart';
+import 'package:overkeys/widgets/preferences/text_tab.dart';
+import 'package:overkeys/widgets/preferences/about_tab.dart';
 
 class PreferencesScreen extends StatefulWidget {
   const PreferencesScreen({super.key, required this.windowController});
@@ -24,7 +23,7 @@ class PreferencesScreen extends StatefulWidget {
 
 class _PreferencesScreenState extends State<PreferencesScreen>
     with WindowListener {
-  final SharedPreferencesAsync asyncPrefs = SharedPreferencesAsync();
+  final PreferencesService _prefsService = PreferencesService();
 
   // UI state
   Brightness _brightness = Brightness.dark;
@@ -113,149 +112,100 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     DesktopMultiWindow.setMethodHandler((call, fromWindowId) async {
       if (call.method == 'updateAutoHideFromMainWindow' && mounted) {
         setState(() => _autoHideEnabled = call.arguments as bool);
-        await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
+        await _prefsService.setAutoHideEnabled(_autoHideEnabled);
       }
       return null;
     });
   }
 
   Future<void> _loadPreferences() async {
-    // General settings
-    bool launchAtStartup = await asyncPrefs.getBool('launchAtStartup') ?? false;
-    bool autoHideEnabled = await asyncPrefs.getBool('autoHideEnabled') ?? false;
-    double autoHideDuration =
-        await asyncPrefs.getDouble('autoHideDuration') ?? 2.0;
-    String keyboardLayoutName =
-        await asyncPrefs.getString('layout') ?? 'QWERTY';
-    bool enableAdvancedSettings =
-        await asyncPrefs.getBool('enableAdvancedSettings') ?? false;
-    bool useUserLayout = await asyncPrefs.getBool('useUserLayout') ?? false;
-    bool showAltLayout = await asyncPrefs.getBool('showAltLayout') ?? false;
-    bool kanataEnabled = await asyncPrefs.getBool('kanataEnabled') ?? false;
-
-    // Appearance settings
-    double opacity = await asyncPrefs.getDouble('opacity') ?? 0.6;
-    Color keyColorPressed =
-        Color(await asyncPrefs.getInt('keyColorPressed') ?? 0xFF1E1E1E);
-    Color keyColorNotPressed =
-        Color(await asyncPrefs.getInt('keyColorNotPressed') ?? 0xFF77ABFF);
-    Color markerColor =
-        Color(await asyncPrefs.getInt('markerColor') ?? 0xFFFFFFFF);
-    Color markerColorNotPressed =
-        Color(await asyncPrefs.getInt('markerColorNotPressed') ?? 0xFF000000);
-    double markerOffset = await asyncPrefs.getDouble('markerOffset') ?? 10;
-    double markerWidth = await asyncPrefs.getDouble('markerWidth') ?? 10;
-    double markerHeight = await asyncPrefs.getDouble('markerHeight') ?? 2;
-    double markerBorderRadius =
-        await asyncPrefs.getDouble('markerBorderRadius') ?? 10;
-
-    // Keyboard settings
-    String keymapStyle =
-        await asyncPrefs.getString('keymapStyle') ?? 'Staggered';
-    bool showTopRow = await asyncPrefs.getBool('showTopRow') ?? false;
-    bool showGraveKey = await asyncPrefs.getBool('showGraveKey') ?? false;
-    double keySize = await asyncPrefs.getDouble('keySize') ?? 48;
-    double keyBorderRadius =
-        await asyncPrefs.getDouble('keyBorderRadius') ?? 12;
-    double keyPadding = await asyncPrefs.getDouble('keyPadding') ?? 3;
-    double spaceWidth = await asyncPrefs.getDouble('spaceWidth') ?? 320;
-    double splitWidth = await asyncPrefs.getDouble('splitWidth') ?? 100;
-
-    // Text settings
-    String fontFamily = await asyncPrefs.getString('fontFamily') ?? 'GeistMono';
-    double keyFontSize = await asyncPrefs.getDouble('keyFontSize') ?? 20;
-    double spaceFontSize = await asyncPrefs.getDouble('spaceFontSize') ?? 14;
-    FontWeight fontWeight = FontWeight
-        .values[await asyncPrefs.getInt('fontWeight') ?? FontWeight.w500.index];
-    Color keyTextColor =
-        Color(await asyncPrefs.getInt('keyTextColor') ?? 0xFFFFFFFF);
-    Color keyTextColorNotPressed =
-        Color(await asyncPrefs.getInt('keyTextColorNotPressed') ?? 0xFF000000);
+    final prefs = await _prefsService.loadAllPreferences();
 
     setState(() {
       // General settings
-      _launchAtStartup = launchAtStartup;
-      _autoHideEnabled = autoHideEnabled;
-      _autoHideDuration = autoHideDuration;
-      _keyboardLayoutName = keyboardLayoutName;
-      _enableAdvancedSettings = enableAdvancedSettings;
-      _useUserLayout = useUserLayout;
-      _showAltLayout = showAltLayout;
-      _kanataEnabled = kanataEnabled;
+      _launchAtStartup = prefs['launchAtStartup'];
+      _autoHideEnabled = prefs['autoHideEnabled'];
+      _autoHideDuration = prefs['autoHideDuration'];
+      _keyboardLayoutName = prefs['keyboardLayoutName'];
+      _enableAdvancedSettings = prefs['enableAdvancedSettings'];
+      _useUserLayout = prefs['useUserLayout'];
+      _showAltLayout = prefs['showAltLayout'];
+      _kanataEnabled = prefs['kanataEnabled'];
 
       // Appearance settings
-      _opacity = opacity;
-      _keyColorPressed = keyColorPressed;
-      _keyColorNotPressed = keyColorNotPressed;
-      _markerColor = markerColor;
-      _markerColorNotPressed = markerColorNotPressed;
-      _markerOffset = markerOffset;
-      _markerWidth = markerWidth;
-      _markerHeight = markerHeight;
-      _markerBorderRadius = markerBorderRadius;
+      _opacity = prefs['opacity'];
+      _keyColorPressed = prefs['keyColorPressed'];
+      _keyColorNotPressed = prefs['keyColorNotPressed'];
+      _markerColor = prefs['markerColor'];
+      _markerColorNotPressed = prefs['markerColorNotPressed'];
+      _markerOffset = prefs['markerOffset'];
+      _markerWidth = prefs['markerWidth'];
+      _markerHeight = prefs['markerHeight'];
+      _markerBorderRadius = prefs['markerBorderRadius'];
 
       // Keyboard settings
-      _keymapStyle = keymapStyle;
-      _showTopRow = showTopRow;
-      _showGraveKey = showGraveKey;
-      _keySize = keySize;
-      _keyBorderRadius = keyBorderRadius;
-      _keyPadding = keyPadding;
-      _spaceWidth = spaceWidth;
-      _splitWidth = splitWidth;
+      _keymapStyle = prefs['keymapStyle'];
+      _showTopRow = prefs['showTopRow'];
+      _showGraveKey = prefs['showGraveKey'];
+      _keySize = prefs['keySize'];
+      _keyBorderRadius = prefs['keyBorderRadius'];
+      _keyPadding = prefs['keyPadding'];
+      _spaceWidth = prefs['spaceWidth'];
+      _splitWidth = prefs['splitWidth'];
 
       // Text settings
-      _fontFamily = fontFamily;
-      _keyFontSize = keyFontSize;
-      _spaceFontSize = spaceFontSize;
-      _fontWeight = fontWeight;
-      _keyTextColor = keyTextColor;
-      _keyTextColorNotPressed = keyTextColorNotPressed;
+      _fontFamily = prefs['fontFamily'];
+      _keyFontSize = prefs['keyFontSize'];
+      _spaceFontSize = prefs['spaceFontSize'];
+      _fontWeight = prefs['fontWeight'];
+      _keyTextColor = prefs['keyTextColor'];
+      _keyTextColorNotPressed = prefs['keyTextColorNotPressed'];
     });
   }
 
   Future<void> _savePreferences() async {
-    // General settings
-    await asyncPrefs.setBool('launchAtStartup', _launchAtStartup);
-    await asyncPrefs.setBool('autoHideEnabled', _autoHideEnabled);
-    await asyncPrefs.setDouble('autoHideDuration', _autoHideDuration);
-    await asyncPrefs.setString('layout', _keyboardLayoutName);
-    await asyncPrefs.setBool('enableAdvancedSettings', _enableAdvancedSettings);
-    await asyncPrefs.setBool('useUserLayout', _useUserLayout);
-    await asyncPrefs.setBool('showAltLayout', _showAltLayout);
-    await asyncPrefs.setBool('kanataEnabled', _kanataEnabled);
+    final prefs = {
+      // General settings
+      'launchAtStartup': _launchAtStartup,
+      'autoHideEnabled': _autoHideEnabled,
+      'autoHideDuration': _autoHideDuration,
+      'keyboardLayoutName': _keyboardLayoutName,
+      'enableAdvancedSettings': _enableAdvancedSettings,
+      'useUserLayout': _useUserLayout,
+      'showAltLayout': _showAltLayout,
+      'kanataEnabled': _kanataEnabled,
 
-    // Appearance settings
-    await asyncPrefs.setDouble('opacity', _opacity);
-    await asyncPrefs.setInt('keyColorPressed', _keyColorPressed.toARGB32());
-    await asyncPrefs.setInt(
-        'keyColorNotPressed', _keyColorNotPressed.toARGB32());
-    await asyncPrefs.setInt('markerColor', _markerColor.toARGB32());
-    await asyncPrefs.setInt(
-        'markerColorNotPressed', _markerColorNotPressed.toARGB32());
-    await asyncPrefs.setDouble('markerOffset', _markerOffset);
-    await asyncPrefs.setDouble('markerWidth', _markerWidth);
-    await asyncPrefs.setDouble('markerHeight', _markerHeight);
-    await asyncPrefs.setDouble('markerBorderRadius', _markerBorderRadius);
+      // Appearance settings
+      'opacity': _opacity,
+      'keyColorPressed': _keyColorPressed,
+      'keyColorNotPressed': _keyColorNotPressed,
+      'markerColor': _markerColor,
+      'markerColorNotPressed': _markerColorNotPressed,
+      'markerOffset': _markerOffset,
+      'markerWidth': _markerWidth,
+      'markerHeight': _markerHeight,
+      'markerBorderRadius': _markerBorderRadius,
 
-    // Keyboard settings
-    await asyncPrefs.setString('keymapStyle', _keymapStyle);
-    await asyncPrefs.setBool('showTopRow', _showTopRow);
-    await asyncPrefs.setBool('showGraveKey', _showGraveKey);
-    await asyncPrefs.setDouble('keySize', _keySize);
-    await asyncPrefs.setDouble('keyBorderRadius', _keyBorderRadius);
-    await asyncPrefs.setDouble('keyPadding', _keyPadding);
-    await asyncPrefs.setDouble('spaceWidth', _spaceWidth);
-    await asyncPrefs.setDouble('splitWidth', _splitWidth);
+      // Keyboard settings
+      'keymapStyle': _keymapStyle,
+      'showTopRow': _showTopRow,
+      'showGraveKey': _showGraveKey,
+      'keySize': _keySize,
+      'keyBorderRadius': _keyBorderRadius,
+      'keyPadding': _keyPadding,
+      'spaceWidth': _spaceWidth,
+      'splitWidth': _splitWidth,
 
-    // Text settings
-    await asyncPrefs.setString('fontFamily', _fontFamily);
-    await asyncPrefs.setDouble('keyFontSize', _keyFontSize);
-    await asyncPrefs.setDouble('spaceFontSize', _spaceFontSize);
-    await asyncPrefs.setInt('fontWeight', _fontWeight.index);
-    await asyncPrefs.setInt('keyTextColor', _keyTextColor.toARGB32());
-    await asyncPrefs.setInt(
-        'keyTextColorNotPressed', _keyTextColorNotPressed.toARGB32());
+      // Text settings
+      'fontFamily': _fontFamily,
+      'keyFontSize': _keyFontSize,
+      'spaceFontSize': _spaceFontSize,
+      'fontWeight': _fontWeight,
+      'keyTextColor': _keyTextColor,
+      'keyTextColorNotPressed': _keyTextColorNotPressed,
+    };
+
+    await _prefsService.saveAllPreferences(prefs);
   }
 
   void _updateMainWindow(dynamic method, dynamic value) async {
@@ -350,799 +300,178 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   Widget _buildCurrentTabContent() {
     switch (_currentTab) {
       case 'General':
-        return _buildGeneralTab();
-      case 'Appearance':
-        return _buildAppearanceTab();
-      case 'Text':
-        return _buildTextTab();
-      case 'Keyboard':
-        return _buildKeyboardTab();
-      case 'About':
-        return _buildAboutTab();
-      default:
-        return const SizedBox.shrink();
-    }
-  }
-
-  Widget _buildGeneralTab() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        _buildSectionTitle('General Settings'),
-        _buildToggleOption('Open on system startup', _launchAtStartup, (value) {
-          setState(() => _launchAtStartup = value);
-          _updateMainWindow('updateLaunchAtStartup', value);
-        }),
-        _buildToggleOption('Auto-hide keyboard', _autoHideEnabled, (value) {
-          setState(() => _autoHideEnabled = value);
-          _updateMainWindow('updateAutoHideEnabled', value);
-        }),
-        AnimatedCrossFade(
-          duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox.shrink(),
-          secondChild: _buildSliderOption(
-              'Auto-hide duration (seconds)', _autoHideDuration, 0.5, 5.0, 9,
-              (value) {
+        return GeneralTab(
+          launchAtStartup: _launchAtStartup,
+          autoHideEnabled: _autoHideEnabled,
+          autoHideDuration: _autoHideDuration,
+          keyboardLayoutName: _keyboardLayoutName,
+          enableAdvancedSettings: _enableAdvancedSettings,
+          useUserLayout: _useUserLayout,
+          showAltLayout: _showAltLayout,
+          kanataEnabled: _kanataEnabled,
+          updateLaunchAtStartup: (value) {
+            setState(() => _launchAtStartup = value);
+            _updateMainWindow('updateLaunchAtStartup', value);
+          },
+          updateAutoHideEnabled: (value) {
+            setState(() => _autoHideEnabled = value);
+            _updateMainWindow('updateAutoHideEnabled', value);
+          },
+          updateAutoHideDuration: (value) {
             double roundedValue = (value * 2).round() / 2;
             setState(() => _autoHideDuration = roundedValue);
             _updateMainWindow('updateAutoHideDuration', roundedValue);
-          }, valueDisplayFormatter: (value) => value.toStringAsFixed(1)),
-          crossFadeState: _autoHideEnabled
-              ? CrossFadeState.showSecond
-              : CrossFadeState.showFirst,
-          sizeCurve: Curves.easeInOut,
-        ),
-        _buildDropdownOption('Layout', _keyboardLayoutName,
-            availableLayouts.map((layout) => (layout.name)).toList(), (value) {
-          setState(() => _keyboardLayoutName = value!);
-          _updateMainWindow('updateLayout', value);
-        }),
-        _buildToggleOption('Turn on advanced settings', _enableAdvancedSettings,
-            (value) {
-          setState(() => _enableAdvancedSettings = value);
-          _updateMainWindow('updateEnableAdvancedSettings', value);
-        }),
-        AnimatedCrossFade(
-          duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox.shrink(),
-          secondChild: Column(
-            children: [
-              _buildToggleOption(
-                  'Use custom layout from config', _useUserLayout,
-                  subtitle:
-                      'Sets layout to user-defined defaultUserLayout. Make sure that the layout is saved in the config file.',
-                  (value) {
-                if (value && _kanataEnabled) {
-                  setState(() {
-                    _useUserLayout = value;
-                    _kanataEnabled = false;
-                  });
-                  _updateMainWindow('updateKanataEnabled', false);
-                } else {
-                  setState(() => _useUserLayout = value);
-                }
-                _updateMainWindow('updateUseUserLayout', value);
-              }),
-              _buildToggleOption('Show alternative layout', _showAltLayout,
-                  (value) {
-                setState(() => _showAltLayout = value);
-                _updateMainWindow('updateShowAltLayout', value);
-              }),
-              _buildToggleOption('Connect to Kanata', _kanataEnabled,
-                  subtitle:
-                      'Make sure that Kanata and OverKeys are using the same port. Restart OverKeys if config file changes were made to apply changes.',
-                  (value) {
-                if (value && _useUserLayout) {
-                  setState(() {
-                    _kanataEnabled = value;
-                    _useUserLayout = false;
-                  });
-                  _updateMainWindow('updateUseUserLayout', false);
-                } else {
-                  setState(() => _kanataEnabled = value);
-                }
-                _updateMainWindow('updateKanataEnabled', value);
-              }),
-              _buildOpenConfigButton(),
-            ],
-          ),
-          crossFadeState: _enableAdvancedSettings
-              ? CrossFadeState.showSecond
-              : CrossFadeState.showFirst,
-          sizeCurve: Curves.easeInOut,
-        ),
-      ],
-    );
-  }
-
-  Widget _buildAppearanceTab() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        _buildSectionTitle('Appearance Settings'),
-        _buildSliderOption('Opacity', _opacity, 0.1, 1.0, 18, (value) {
-          setState(() => _opacity = value);
-          _updateMainWindow('updateOpacity', value);
-        }),
-        _buildColorOption('Key color (pressed)', _keyColorPressed, (color) {
-          setState(() => _keyColorPressed = color);
-          _updateMainWindow('updateKeyColorPressed', color);
-        }),
-        _buildColorOption('Key color (not pressed)', _keyColorNotPressed,
-            (color) {
-          setState(() => _keyColorNotPressed = color);
-          _updateMainWindow('updateKeyColorNotPressed', color);
-        }),
-        _buildSectionTitle('Tactile Markers'),
-        _buildColorOption('Marker color (pressed)', _markerColor, (color) {
-          setState(() => _markerColor = color);
-          _updateMainWindow('updateMarkerColor', color);
-        }),
-        _buildColorOption('Marker color (not pressed)', _markerColorNotPressed,
-            (color) {
-          setState(() => _markerColorNotPressed = color);
-          _updateMainWindow('updateMarkerColorNotPressed', color);
-        }),
-        _buildSliderOption('Marker offset', _markerOffset, 0, 20, 20, (value) {
-          setState(() => _markerOffset = value);
-          _updateMainWindow('updateMarkerOffset', value);
-        }),
-        _buildSliderOption('Marker width', _markerWidth, 0, 20, 20,
-            subtitle: _showAltLayout
-                ? 'When alternative layout is shown, marker width appear at half the size (width × 0.5)'
-                : null, (value) {
-          setState(() => _markerWidth = value);
-          _updateMainWindow('updateMarkerWidth', value);
-        }),
-        _buildSliderOption('Marker height', _markerHeight, 0, 10, 10,
-            subtitle: _showAltLayout
-                ? 'When alternative layout is shown, marker height is not used and instead equals the marker width after computation'
-                : null, (value) {
-          setState(() => _markerHeight = value);
-          _updateMainWindow('updateMarkerHeight', value);
-        }),
-        _buildSliderOption(
-            'Marker border radius', _markerBorderRadius, 0, 10, 10, (value) {
-          setState(() => _markerBorderRadius = value);
-          _updateMainWindow('updateMarkerBorderRadius', value);
-        }),
-      ],
-    );
-  }
-
-  Widget _buildKeyboardTab() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        _buildSectionTitle('Keyboard Layout'),
-        _buildDropdownOption('Keymap style', _keymapStyle,
-            ['Staggered', 'Matrix', 'Split Matrix'], (value) {
-          if (value == 'Split Matrix' && _spaceWidth > 300) {
-            _updateMainWindow('updateSpaceWidth', 220.0);
-            setState(() => _spaceWidth = 220);
-          }
-          setState(() => _keymapStyle = value!);
-          _updateMainWindow('updateKeymapStyle', value);
-        }),
-        _buildToggleOption('Show top row', _showTopRow,
-            subtitle:
-                'Recommended to toggle when keyboard is visible or auto-hide is off. Toggling while hidden may cause rendering errors.',
-            (value) {
-          setState(() => _showTopRow = value);
-          _updateMainWindow('updateShowTopRow', value);
-        }),
-        AnimatedCrossFade(
-          duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox.shrink(),
-          secondChild:
-              _buildToggleOption('Show grave key', _showGraveKey, (value) {
+          },
+          updateKeyboardLayoutName: (value) {
+            setState(() => _keyboardLayoutName = value);
+            _updateMainWindow('updateLayout', value);
+          },
+          updateEnableAdvancedSettings: (value) {
+            setState(() => _enableAdvancedSettings = value);
+            _updateMainWindow('updateEnableAdvancedSettings', value);
+          },
+          updateUseUserLayout: (value) {
+            setState(() => _useUserLayout = value);
+            _updateMainWindow('updateUseUserLayout', value);
+          },
+          updateShowAltLayout: (value) {
+            setState(() => _showAltLayout = value);
+            _updateMainWindow('updateShowAltLayout', value);
+          },
+          updateKanataEnabled: (value) {
+            setState(() => _kanataEnabled = value);
+            _updateMainWindow('updateKanataEnabled', value);
+          },
+        );
+      case 'Appearance':
+        return AppearanceTab(
+          opacity: _opacity,
+          keyColorPressed: _keyColorPressed,
+          keyColorNotPressed: _keyColorNotPressed,
+          markerColor: _markerColor,
+          markerColorNotPressed: _markerColorNotPressed,
+          markerOffset: _markerOffset,
+          markerWidth: _markerWidth,
+          markerHeight: _markerHeight,
+          markerBorderRadius: _markerBorderRadius,
+          showAltLayout: _showAltLayout,
+          updateOpacity: (value) {
+            setState(() => _opacity = value);
+            _updateMainWindow('updateOpacity', value);
+          },
+          updateKeyColorPressed: (value) {
+            setState(() => _keyColorPressed = value);
+            _updateMainWindow('updateKeyColorPressed', value);
+          },
+          updateKeyColorNotPressed: (value) {
+            setState(() => _keyColorNotPressed = value);
+            _updateMainWindow('updateKeyColorNotPressed', value);
+          },
+          updateMarkerColor: (value) {
+            setState(() => _markerColor = value);
+            _updateMainWindow('updateMarkerColor', value);
+          },
+          updateMarkerColorNotPressed: (value) {
+            setState(() => _markerColorNotPressed = value);
+            _updateMainWindow('updateMarkerColorNotPressed', value);
+          },
+          updateMarkerOffset: (value) {
+            setState(() => _markerOffset = value);
+            _updateMainWindow('updateMarkerOffset', value);
+          },
+          updateMarkerWidth: (value) {
+            setState(() => _markerWidth = value);
+            _updateMainWindow('updateMarkerWidth', value);
+          },
+          updateMarkerHeight: (value) {
+            setState(() => _markerHeight = value);
+            _updateMainWindow('updateMarkerHeight', value);
+          },
+          updateMarkerBorderRadius: (value) {
+            setState(() => _markerBorderRadius = value);
+            _updateMainWindow('updateMarkerBorderRadius', value);
+          },
+        );
+      case 'Keyboard':
+        return KeyboardTab(
+          keymapStyle: _keymapStyle,
+          showTopRow: _showTopRow,
+          showGraveKey: _showGraveKey,
+          keySize: _keySize,
+          keyBorderRadius: _keyBorderRadius,
+          keyPadding: _keyPadding,
+          spaceWidth: _spaceWidth,
+          splitWidth: _splitWidth,
+          updateKeymapStyle: (value) {
+            setState(() => _keymapStyle = value);
+            _updateMainWindow('updateKeymapStyle', value);
+          },
+          updateShowTopRow: (value) {
+            setState(() => _showTopRow = value);
+            _updateMainWindow('updateShowTopRow', value);
+          },
+          updateShowGraveKey: (value) {
             setState(() => _showGraveKey = value);
             _updateMainWindow('updateShowGraveKey', value);
-          }),
-          crossFadeState: _showTopRow
-              ? CrossFadeState.showSecond
-              : CrossFadeState.showFirst,
-          sizeCurve: Curves.easeInOut,
-        ),
-        _buildSectionTitle('Key Dimensions'),
-        AnimatedCrossFade(
-          duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox.shrink(),
-          secondChild: _buildSliderOption(
-              'Split width', _splitWidth, 30, 200, 34, (value) {
+          },
+          updateKeySize: (value) {
+            setState(() => _keySize = value);
+            _updateMainWindow('updateKeySize', value);
+          },
+          updateKeyBorderRadius: (value) {
+            setState(() => _keyBorderRadius = value);
+            _updateMainWindow('updateKeyBorderRadius', value);
+          },
+          updateKeyPadding: (value) {
+            setState(() => _keyPadding = value);
+            _updateMainWindow('updateKeyPadding', value);
+          },
+          updateSpaceWidth: (value) {
+            setState(() => _spaceWidth = value);
+            _updateMainWindow('updateSpaceWidth', value);
+          },
+          updateSplitWidth: (value) {
             setState(() => _splitWidth = value);
             _updateMainWindow('updateSplitWidth', value);
-          }),
-          crossFadeState: _keymapStyle == 'Split Matrix'
-              ? CrossFadeState.showSecond
-              : CrossFadeState.showFirst,
-          sizeCurve: Curves.easeInOut,
-        ),
-        _buildSliderOption('Key size', _keySize, 40, 60, 40, (value) {
-          setState(() => _keySize = value);
-          _updateMainWindow('updateKeySize', value);
-        }),
-        _buildSliderOption('Key border radius', _keyBorderRadius, 0, 30, 30,
-            (value) {
-          setState(() => _keyBorderRadius = value);
-          _updateMainWindow('updateKeyBorderRadius', value);
-        }),
-        _buildSliderOption('Key padding', _keyPadding, 0, 10, 20, (value) {
-          setState(() => _keyPadding = value);
-          _updateMainWindow('updateKeyPadding', value);
-        }),
-        _buildSliderOption(
-            'Space width',
-            _spaceWidth,
-            120,
-            (_keymapStyle == 'Split Matrix') ? 300 : 500,
-            (_keymapStyle == 'Split Matrix') ? 90 : 190, (value) {
-          setState(() => _spaceWidth = value);
-          _updateMainWindow('updateSpaceWidth', value);
-        }),
-      ],
-    );
-  }
-
-  Widget _buildTextTab() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        _buildSectionTitle('Text Settings'),
-        _buildDropdownOption('Font style', _fontFamily, [
-          'Berkeley Mono',
-          'Cascadia Mono',
-          'Comic Mono',
-          'CommitMono',
-          'Consolas',
-          'Courier',
-          'Cousine',
-          'Dank Mono',
-          'DM Mono',
-          'Droid Sans Mono',
-          'Fira Code',
-          'Fira Mono',
-          'Geist',
-          'GeistMono',
-          'Google Sans',
-          'Hack',
-          'IBM Plex Mono',
-          'Inconsolata',
-          'Input',
-          'Inter',
-          'Iosevka',
-          'JetBrains Mono',
-          'Manrope',
-          'Meslo',
-          'Monaspace Argon',
-          'Monaspace Krypton',
-          'Monaspace Neon',
-          'Monaspace Radon',
-          'Monaspace Xenon',
-          'Monocraft',
-          'MonoLisa',
-          'mononoki',
-          'Montserrat',
-          'Nunito',
-          'Poppins',
-          'Roboto',
-          'Roboto Mono',
-          'Source Code Pro',
-          'Source Sans Pro',
-          'Ubuntu',
-          'Ubuntu Mono',
-          'Victor Mono',
-        ], (value) {
-          setState(() => _fontFamily = value!);
-          _updateMainWindow('updateFontFamily', value);
-        },
-            subtitle:
-                'Make sure that the font is installed in your system. Falls back to Geist Mono.'),
-        _buildSliderOption('Key font size', _keyFontSize, 12, 32, 40, (value) {
-          setState(() => _keyFontSize = value);
-          _updateMainWindow('updateKeyFontSize', value);
-        }),
-        _buildSliderOption('Space font size', _spaceFontSize, 12, 32, 40,
-            (value) {
-          setState(() => _spaceFontSize = value);
-          _updateMainWindow('updateSpaceFontSize', value);
-        }),
-        _buildDropdownOption(
-            'Font weight',
-            _fontWeight == FontWeight.w100
-                ? 'Thin'
-                : _fontWeight == FontWeight.w200
-                    ? 'ExtraLight'
-                    : _fontWeight == FontWeight.w300
-                        ? 'Light'
-                        : _fontWeight == FontWeight.normal
-                            ? 'Normal'
-                            : _fontWeight == FontWeight.w500
-                                ? 'Medium'
-                                : _fontWeight == FontWeight.w600
-                                    ? 'SemiBold'
-                                    : _fontWeight == FontWeight.bold
-                                        ? 'Bold'
-                                        : _fontWeight == FontWeight.w800
-                                            ? 'ExtraBold'
-                                            : 'Black',
-            [
-              'Thin',
-              'ExtraLight',
-              'Light',
-              'Normal',
-              'Medium',
-              'SemiBold',
-              'Bold',
-              'ExtraBold',
-              'Black'
-            ], (value) {
-          setState(() {
-            switch (value) {
-              case 'Thin':
-                _fontWeight = FontWeight.w100;
-                break;
-              case 'ExtraLight':
-                _fontWeight = FontWeight.w200;
-                break;
-              case 'Light':
-                _fontWeight = FontWeight.w300;
-                break;
-              case 'Normal':
-                _fontWeight = FontWeight.normal;
-                break;
-              case 'Medium':
-                _fontWeight = FontWeight.w500;
-                break;
-              case 'SemiBold':
-                _fontWeight = FontWeight.w600;
-                break;
-              case 'Bold':
-                _fontWeight = FontWeight.bold;
-                break;
-              case 'ExtraBold':
-                _fontWeight = FontWeight.w800;
-                break;
-              case 'Black':
-                _fontWeight = FontWeight.w900;
-                break;
-            }
-          });
-          _updateMainWindow('updateFontWeight', _fontWeight.index);
-        }),
-        _buildColorOption('Text color (pressed)', _keyTextColor, (color) {
-          setState(() => _keyTextColor = color);
-          _updateMainWindow('updateKeyTextColor', color);
-        }),
-        _buildColorOption('Text color (not pressed)', _keyTextColorNotPressed,
-            (color) {
-          setState(() => _keyTextColorNotPressed = color);
-          _updateMainWindow('updateKeyTextColorNotPressed', color);
-        }),
-      ],
-    );
-  }
-
-  Widget _buildAboutTab() {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-
-    return SizedBox(
-      width: double.infinity,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          _buildSectionTitle('About'),
-          const SizedBox(height: 20),
-          Image.asset('assets/images/app_icon.png', width: 120),
-          const SizedBox(height: 20),
-          Text('OverKeys',
-              style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontSize: 28,
-                  fontWeight: FontWeight.w900)),
-          const SizedBox(height: 20),
-          Text('Version: $_appVersion',
-              style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600)),
-          const SizedBox(height: 10),
-          Text('© 2024 Angelo Convento',
-              style: TextStyle(
-                  color: colorScheme.onSurface.withAlpha(153),
-                  fontSize: 15,
-                  fontWeight: FontWeight.w500)),
-          const SizedBox(height: 20),
-          ElevatedButton.icon(
-            onPressed: () async {
-              await launchUrl(
-                  Uri.parse('https://github.com/conventoangelo/overkeys'),
-                  mode: LaunchMode.externalApplication);
-            },
-            icon: ImageIcon(
-              AssetImage('assets/images/github-mark.png'),
-              size: 20,
-            ),
-            label: Text(
-              'View on GitHub',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            style: ElevatedButton.styleFrom(
-              minimumSize: const Size(200, 50),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSectionTitle(String title) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 16),
-      child: Text(
-        title,
-        style: TextStyle(
-            color: colorScheme.onSurface,
-            fontSize: 20,
-            fontWeight: FontWeight.bold),
-      ),
-    );
-  }
-
-  Widget _buildToggleOption(String label, bool value, Function(bool) onChanged,
-      {String? subtitle}) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-    const WidgetStateProperty<Icon> thumbIcon =
-        WidgetStateProperty<Icon>.fromMap(
-      <WidgetStatesConstraint, Icon>{
-        WidgetState.selected: Icon(Icons.check),
-        WidgetState.any: Icon(Icons.close),
-      },
-    );
-    return _buildOptionContainer(
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(label,
-                    style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                        fontSize: 16)),
-                if (subtitle != null)
-                  Text(
-                    subtitle,
-                    style: TextStyle(
-                        color: colorScheme.onSurface.withAlpha(153),
-                        fontSize: 14.0),
-                    softWrap: true,
-                    overflow: TextOverflow.visible,
-                  ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 16),
-          Switch(
-            thumbIcon: thumbIcon,
-            value: value,
-            onChanged: onChanged,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildDropdownOption(String label, String value, List<String> options,
-      Function(String?) onChanged,
-      {String? subtitle}) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-    final TextEditingController controller = TextEditingController(text: value);
-
-    return _buildOptionContainer(
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(label,
-                    style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                        fontSize: 16)),
-                if (subtitle != null)
-                  Text(
-                    subtitle,
-                    style: TextStyle(
-                        color: colorScheme.onSurface.withAlpha(153),
-                        fontSize: 14.0),
-                    softWrap: true,
-                    overflow: TextOverflow.visible,
-                  ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 40),
-          DropdownMenu<String>(
-            controller: controller,
-            initialSelection: value,
-            requestFocusOnTap: true,
-            enableFilter: true,
-            width: 210,
-            menuHeight: 300,
-            dropdownMenuEntries: options
-                .map((String option) => DropdownMenuEntry<String>(
-                      value: option,
-                      label: option,
-                      style: MenuItemButton.styleFrom(
-                        textStyle: TextStyle(
-                          fontFamily: option,
-                          fontFamilyFallback: const ['Manrope'],
-                          fontSize: 15,
-                        ),
-                      ),
-                    ))
-                .toList(),
-            onSelected: (String? newValue) {
-              if (newValue != null) {
-                onChanged(newValue);
-              }
-            },
-            textStyle: TextStyle(
-              fontFamily: value,
-              fontFamilyFallback: const ['Manrope'],
-              fontSize: 15,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildOpenConfigButton() {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-
-    return _buildOptionContainer(
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Open config file',
-                    style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                        fontSize: 16)),
-                Text(
-                  'Turn related advanced setting off then on again to apply changes',
-                  style: TextStyle(
-                      color: colorScheme.onSurface.withAlpha(153),
-                      fontSize: 14.0),
-                  softWrap: true,
-                  overflow: TextOverflow.visible,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 16),
-          ElevatedButton.icon(
-            icon: Icon(Icons.file_open, color: colorScheme.primary),
-            label: Text('Open',
-                style: TextStyle(
-                  color: colorScheme.primary,
-                  fontWeight: FontWeight.w700,
-                  fontSize: 16,
-                )),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: colorScheme.surfaceContainerHighest,
-              elevation: 2,
-              minimumSize: const Size(100, 45),
-              side: BorderSide(color: colorScheme.primary),
-            ),
-            onPressed: () async {
-              try {
-                final configService = ConfigService();
-                final configPath = await configService.configPath;
-                final file = File(configPath);
-
-                if (await file.exists()) {
-                  Process.start('cmd.exe', ['/c', 'start', '', configPath]);
-                } else {
-                  await configService.saveConfig(UserConfig());
-                  Process.start('cmd.exe', ['/c', 'start', '', configPath]);
-                }
-              } catch (e) {
-                debugPrint('Error opening config file: $e');
-              }
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSliderOption(String label, double value, double min, double max,
-      int divisions, Function(double) onChanged,
-      {String Function(double)? valueDisplayFormatter, String? subtitle}) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-    return _buildOptionContainer(
-      Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label,
-              style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16)),
-          if (subtitle != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
-              child: Text(
-                subtitle,
-                style: TextStyle(
-                    color: colorScheme.onSurface.withAlpha(153),
-                    fontSize: 14.0),
-                softWrap: true,
-                overflow: TextOverflow.visible,
-              ),
-            )
-          else
-            const SizedBox(height: 8.0),
-          Slider(
-            value: value,
-            min: min,
-            divisions: divisions,
-            label: valueDisplayFormatter != null
-                ? valueDisplayFormatter(value)
-                : value.toStringAsFixed(2),
-            max: max,
-            onChanged: (value) {
-              final Map<String, Function(double)> updates = {
-                'Key font size': (v) => _keyFontSize = v,
-                'Space font size': (v) => _spaceFontSize = v,
-                'Key size': (v) => _keySize = v,
-                'Key border radius': (v) => _keyBorderRadius = v,
-                'Key padding': (v) => _keyPadding = v,
-                'Space width': (v) => _spaceWidth = v,
-                'Split width': (v) => _splitWidth = v,
-                'Opacity': (v) => _opacity = v,
-                'Auto-hide duration (seconds)': (v) =>
-                    _autoHideDuration = (v * 2).round() / 2,
-                'Marker offset': (v) => _markerOffset = v,
-                'Marker width': (v) => _markerWidth = v,
-                'Marker height': (v) => _markerHeight = v,
-                'Marker border radius': (v) => _markerBorderRadius = v,
-              };
-              setState(() {
-                updates[label]?.call(value);
-              });
-            },
-            onChangeEnd: onChanged,
-            // ignore: deprecated_member_use
-            year2023: false,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildColorOption(
-      String label, Color currentColor, Function(Color) onColorChanged) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-
-    return _buildOptionContainer(
-      Builder(builder: (context) {
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label,
-                style: TextStyle(
-                    color: colorScheme.onSurface,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 16)),
-            ColorIndicator(
-              width: 44,
-              height: 44,
-              borderRadius: 11,
-              color: currentColor,
-              onSelectFocus: false,
-              onSelect: () async {
-                final Color? newColor = await showDialog<Color>(
-                  context: context,
-                  builder: (BuildContext context) {
-                    Color pickerColor = currentColor;
-                    return AlertDialog(
-                      backgroundColor: colorScheme.surface,
-                      content: SingleChildScrollView(
-                        child: ColorPicker(
-                          wheelDiameter: 250,
-                          wheelWidth: 22,
-                          wheelSquarePadding: 4,
-                          wheelSquareBorderRadius: 16,
-                          wheelHasBorder: true,
-                          color: pickerColor,
-                          onColorChanged: (Color color) {
-                            pickerColor = color;
-                          },
-                          heading: Text(
-                            'Select color',
-                            style: TextStyle(
-                              color: colorScheme.onSurface,
-                            ),
-                          ),
-                          showColorName: true,
-                          showColorCode: true,
-                          copyPasteBehavior: const ColorPickerCopyPasteBehavior(
-                            copyButton: true,
-                            pasteButton: true,
-                            ctrlC: true,
-                            ctrlV: true,
-                          ),
-                          colorNameTextStyle:
-                              TextStyle(color: colorScheme.onSurface),
-                          colorCodeTextStyle:
-                              TextStyle(color: colorScheme.onSurface),
-                          pickersEnabled: const <ColorPickerType, bool>{
-                            ColorPickerType.primary: false,
-                            ColorPickerType.accent: false,
-                            ColorPickerType.wheel: true,
-                          },
-                        ),
-                      ),
-                      actions: <Widget>[
-                        TextButton(
-                          child: Text('Cancel',
-                              style: TextStyle(color: colorScheme.primary)),
-                          onPressed: () {
-                            onColorChanged(currentColor);
-                            Navigator.of(context).pop();
-                          },
-                        ),
-                        TextButton(
-                          child: Text('OK',
-                              style: TextStyle(color: colorScheme.primary)),
-                          onPressed: () {
-                            Navigator.of(context).pop(pickerColor);
-                          },
-                        ),
-                      ],
-                    );
-                  },
-                );
-                if (newColor != null) {
-                  onColorChanged(newColor);
-                }
-              },
-            ),
-          ],
+          },
         );
-      }),
-    );
-  }
-
-  Widget _buildOptionContainer(Widget child) {
-    final colorScheme = ThemeManager.getTheme(_brightness).colorScheme;
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: child,
-    );
+      case 'Text':
+        return TextTab(
+          fontFamily: _fontFamily,
+          keyFontSize: _keyFontSize,
+          spaceFontSize: _spaceFontSize,
+          fontWeight: _fontWeight,
+          keyTextColor: _keyTextColor,
+          keyTextColorNotPressed: _keyTextColorNotPressed,
+          updateFontFamily: (value) {
+            setState(() => _fontFamily = value);
+            _updateMainWindow('updateFontFamily', value);
+          },
+          updateKeyFontSize: (value) {
+            setState(() => _keyFontSize = value);
+            _updateMainWindow('updateKeyFontSize', value);
+          },
+          updateSpaceFontSize: (value) {
+            setState(() => _spaceFontSize = value);
+            _updateMainWindow('updateSpaceFontSize', value);
+          },
+          updateFontWeight: (value) {
+            setState(() => _fontWeight = value);
+            _updateMainWindow('updateFontWeight', value);
+          },
+          updateKeyTextColor: (value) {
+            setState(() => _keyTextColor = value);
+            _updateMainWindow('updateKeyTextColor', value);
+          },
+          updateKeyTextColorNotPressed: (value) {
+            setState(() => _keyTextColorNotPressed = value);
+            _updateMainWindow('updateKeyTextColorNotPressed', value);
+          },
+        );
+      case 'About':
+        return AboutTab(appVersion: _appVersion);
+      default:
+        return const SizedBox.shrink();
+    }
   }
 }

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  final SharedPreferencesAsync asyncPrefs = SharedPreferencesAsync();
+
+  // General settings
+  Future<bool> getLaunchAtStartup() async =>
+      await asyncPrefs.getBool('launchAtStartup') ?? false;
+  Future<bool> getAutoHideEnabled() async =>
+      await asyncPrefs.getBool('autoHideEnabled') ?? false;
+  Future<double> getAutoHideDuration() async =>
+      await asyncPrefs.getDouble('autoHideDuration') ?? 2.0;
+  Future<String> getKeyboardLayoutName() async =>
+      await asyncPrefs.getString('layout') ?? 'QWERTY';
+  Future<bool> getEnableAdvancedSettings() async =>
+      await asyncPrefs.getBool('enableAdvancedSettings') ?? false;
+  Future<bool> getUseUserLayout() async =>
+      await asyncPrefs.getBool('useUserLayout') ?? false;
+  Future<bool> getShowAltLayout() async =>
+      await asyncPrefs.getBool('showAltLayout') ?? false;
+  Future<bool> getKanataEnabled() async =>
+      await asyncPrefs.getBool('kanataEnabled') ?? false;
+
+  // Appearance settings
+  Future<double> getOpacity() async =>
+      await asyncPrefs.getDouble('opacity') ?? 0.6;
+  Future<Color> getKeyColorPressed() async =>
+      Color(await asyncPrefs.getInt('keyColorPressed') ?? 0xFF1E1E1E);
+  Future<Color> getKeyColorNotPressed() async =>
+      Color(await asyncPrefs.getInt('keyColorNotPressed') ?? 0xFF77ABFF);
+  Future<Color> getMarkerColor() async =>
+      Color(await asyncPrefs.getInt('markerColor') ?? 0xFFFFFFFF);
+  Future<Color> getMarkerColorNotPressed() async =>
+      Color(await asyncPrefs.getInt('markerColorNotPressed') ?? 0xFF000000);
+  Future<double> getMarkerOffset() async =>
+      await asyncPrefs.getDouble('markerOffset') ?? 10;
+  Future<double> getMarkerWidth() async =>
+      await asyncPrefs.getDouble('markerWidth') ?? 10;
+  Future<double> getMarkerHeight() async =>
+      await asyncPrefs.getDouble('markerHeight') ?? 2;
+  Future<double> getMarkerBorderRadius() async =>
+      await asyncPrefs.getDouble('markerBorderRadius') ?? 10;
+
+  // Keyboard settings
+  Future<String> getKeymapStyle() async =>
+      await asyncPrefs.getString('keymapStyle') ?? 'Staggered';
+  Future<bool> getShowTopRow() async =>
+      await asyncPrefs.getBool('showTopRow') ?? false;
+  Future<bool> getShowGraveKey() async =>
+      await asyncPrefs.getBool('showGraveKey') ?? false;
+  Future<double> getKeySize() async =>
+      await asyncPrefs.getDouble('keySize') ?? 48;
+  Future<double> getKeyBorderRadius() async =>
+      await asyncPrefs.getDouble('keyBorderRadius') ?? 12;
+  Future<double> getKeyPadding() async =>
+      await asyncPrefs.getDouble('keyPadding') ?? 3;
+  Future<double> getSpaceWidth() async =>
+      await asyncPrefs.getDouble('spaceWidth') ?? 320;
+  Future<double> getSplitWidth() async =>
+      await asyncPrefs.getDouble('splitWidth') ?? 100;
+
+  // Text settings
+  Future<String> getFontFamily() async =>
+      await asyncPrefs.getString('fontFamily') ?? 'GeistMono';
+  Future<double> getKeyFontSize() async =>
+      await asyncPrefs.getDouble('keyFontSize') ?? 20;
+  Future<double> getSpaceFontSize() async =>
+      await asyncPrefs.getDouble('spaceFontSize') ?? 14;
+  Future<FontWeight> getFontWeight() async => FontWeight
+      .values[await asyncPrefs.getInt('fontWeight') ?? FontWeight.w500.index];
+  Future<Color> getKeyTextColor() async =>
+      Color(await asyncPrefs.getInt('keyTextColor') ?? 0xFFFFFFFF);
+  Future<Color> getKeyTextColorNotPressed() async =>
+      Color(await asyncPrefs.getInt('keyTextColorNotPressed') ?? 0xFF000000);
+
+  // Save methods
+  Future<void> setLaunchAtStartup(bool value) async =>
+      await asyncPrefs.setBool('launchAtStartup', value);
+  Future<void> setAutoHideEnabled(bool value) async =>
+      await asyncPrefs.setBool('autoHideEnabled', value);
+  Future<void> setAutoHideDuration(double value) async =>
+      await asyncPrefs.setDouble('autoHideDuration', value);
+  Future<void> setKeyboardLayoutName(String value) async =>
+      await asyncPrefs.setString('layout', value);
+  Future<void> setEnableAdvancedSettings(bool value) async =>
+      await asyncPrefs.setBool('enableAdvancedSettings', value);
+  Future<void> setUseUserLayout(bool value) async =>
+      await asyncPrefs.setBool('useUserLayout', value);
+  Future<void> setShowAltLayout(bool value) async =>
+      await asyncPrefs.setBool('showAltLayout', value);
+  Future<void> setKanataEnabled(bool value) async =>
+      await asyncPrefs.setBool('kanataEnabled', value);
+
+  Future<void> setOpacity(double value) async =>
+      await asyncPrefs.setDouble('opacity', value);
+  Future<void> setKeyColorPressed(Color value) async =>
+      await asyncPrefs.setInt('keyColorPressed', value.toARGB32());
+  Future<void> setKeyColorNotPressed(Color value) async =>
+      await asyncPrefs.setInt('keyColorNotPressed', value.toARGB32());
+  Future<void> setMarkerColor(Color value) async =>
+      await asyncPrefs.setInt('markerColor', value.toARGB32());
+  Future<void> setMarkerColorNotPressed(Color value) async =>
+      await asyncPrefs.setInt('markerColorNotPressed', value.toARGB32());
+  Future<void> setMarkerOffset(double value) async =>
+      await asyncPrefs.setDouble('markerOffset', value);
+  Future<void> setMarkerWidth(double value) async =>
+      await asyncPrefs.setDouble('markerWidth', value);
+  Future<void> setMarkerHeight(double value) async =>
+      await asyncPrefs.setDouble('markerHeight', value);
+  Future<void> setMarkerBorderRadius(double value) async =>
+      await asyncPrefs.setDouble('markerBorderRadius', value);
+
+  Future<void> setKeymapStyle(String value) async =>
+      await asyncPrefs.setString('keymapStyle', value);
+  Future<void> setShowTopRow(bool value) async =>
+      await asyncPrefs.setBool('showTopRow', value);
+  Future<void> setShowGraveKey(bool value) async =>
+      await asyncPrefs.setBool('showGraveKey', value);
+  Future<void> setKeySize(double value) async =>
+      await asyncPrefs.setDouble('keySize', value);
+  Future<void> setKeyBorderRadius(double value) async =>
+      await asyncPrefs.setDouble('keyBorderRadius', value);
+  Future<void> setKeyPadding(double value) async =>
+      await asyncPrefs.setDouble('keyPadding', value);
+  Future<void> setSpaceWidth(double value) async =>
+      await asyncPrefs.setDouble('spaceWidth', value);
+  Future<void> setSplitWidth(double value) async =>
+      await asyncPrefs.setDouble('splitWidth', value);
+
+  Future<void> setFontFamily(String value) async =>
+      await asyncPrefs.setString('fontFamily', value);
+  Future<void> setKeyFontSize(double value) async =>
+      await asyncPrefs.setDouble('keyFontSize', value);
+  Future<void> setSpaceFontSize(double value) async =>
+      await asyncPrefs.setDouble('spaceFontSize', value);
+  Future<void> setFontWeight(FontWeight value) async =>
+      await asyncPrefs.setInt('fontWeight', value.index);
+  Future<void> setKeyTextColor(Color value) async =>
+      await asyncPrefs.setInt('keyTextColor', value.toARGB32());
+  Future<void> setKeyTextColorNotPressed(Color value) async =>
+      await asyncPrefs.setInt('keyTextColorNotPressed', value.toARGB32());
+
+  Future<Map<String, dynamic>> loadAllPreferences() async {
+    return {
+      // General settings
+      'launchAtStartup': await getLaunchAtStartup(),
+      'autoHideEnabled': await getAutoHideEnabled(),
+      'autoHideDuration': await getAutoHideDuration(),
+      'keyboardLayoutName': await getKeyboardLayoutName(),
+      'enableAdvancedSettings': await getEnableAdvancedSettings(),
+      'useUserLayout': await getUseUserLayout(),
+      'showAltLayout': await getShowAltLayout(),
+      'kanataEnabled': await getKanataEnabled(),
+
+      // Appearance settings
+      'opacity': await getOpacity(),
+      'keyColorPressed': await getKeyColorPressed(),
+      'keyColorNotPressed': await getKeyColorNotPressed(),
+      'markerColor': await getMarkerColor(),
+      'markerColorNotPressed': await getMarkerColorNotPressed(),
+      'markerOffset': await getMarkerOffset(),
+      'markerWidth': await getMarkerWidth(),
+      'markerHeight': await getMarkerHeight(),
+      'markerBorderRadius': await getMarkerBorderRadius(),
+
+      // Keyboard settings
+      'keymapStyle': await getKeymapStyle(),
+      'showTopRow': await getShowTopRow(),
+      'showGraveKey': await getShowGraveKey(),
+      'keySize': await getKeySize(),
+      'keyBorderRadius': await getKeyBorderRadius(),
+      'keyPadding': await getKeyPadding(),
+      'spaceWidth': await getSpaceWidth(),
+      'splitWidth': await getSplitWidth(),
+
+      // Text settings
+      'fontFamily': await getFontFamily(),
+      'keyFontSize': await getKeyFontSize(),
+      'spaceFontSize': await getSpaceFontSize(),
+      'fontWeight': await getFontWeight(),
+      'keyTextColor': await getKeyTextColor(),
+      'keyTextColorNotPressed': await getKeyTextColorNotPressed(),
+    };
+  }
+
+  Future<void> saveAllPreferences(Map<String, dynamic> prefs) async {
+    // General settings
+    await setLaunchAtStartup(prefs['launchAtStartup']);
+    await setAutoHideEnabled(prefs['autoHideEnabled']);
+    await setAutoHideDuration(prefs['autoHideDuration']);
+    await setKeyboardLayoutName(prefs['keyboardLayoutName']);
+    await setEnableAdvancedSettings(prefs['enableAdvancedSettings']);
+    await setUseUserLayout(prefs['useUserLayout']);
+    await setShowAltLayout(prefs['showAltLayout']);
+    await setKanataEnabled(prefs['kanataEnabled']);
+
+    // Appearance settings
+    await setOpacity(prefs['opacity']);
+    await setKeyColorPressed(prefs['keyColorPressed']);
+    await setKeyColorNotPressed(prefs['keyColorNotPressed']);
+    await setMarkerColor(prefs['markerColor']);
+    await setMarkerColorNotPressed(prefs['markerColorNotPressed']);
+    await setMarkerOffset(prefs['markerOffset']);
+    await setMarkerWidth(prefs['markerWidth']);
+    await setMarkerHeight(prefs['markerHeight']);
+    await setMarkerBorderRadius(prefs['markerBorderRadius']);
+
+    // Keyboard settings
+    await setKeymapStyle(prefs['keymapStyle']);
+    await setShowTopRow(prefs['showTopRow']);
+    await setShowGraveKey(prefs['showGraveKey']);
+    await setKeySize(prefs['keySize']);
+    await setKeyBorderRadius(prefs['keyBorderRadius']);
+    await setKeyPadding(prefs['keyPadding']);
+    await setSpaceWidth(prefs['spaceWidth']);
+    await setSplitWidth(prefs['splitWidth']);
+
+    // Text settings
+    await setFontFamily(prefs['fontFamily']);
+    await setKeyFontSize(prefs['keyFontSize']);
+    await setSpaceFontSize(prefs['spaceFontSize']);
+    await setFontWeight(prefs['fontWeight']);
+    await setKeyTextColor(prefs['keyTextColor']);
+    await setKeyTextColorNotPressed(prefs['keyTextColorNotPressed']);
+  }
+}
+
+class SharedPreferencesAsync {
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> get _instance async {
+    _prefs ??= await SharedPreferences.getInstance();
+    return _prefs!;
+  }
+
+  Future<bool?> getBool(String key) async {
+    final prefs = await _instance;
+    return prefs.containsKey(key) ? prefs.getBool(key) : null;
+  }
+
+  Future<int?> getInt(String key) async {
+    final prefs = await _instance;
+    return prefs.containsKey(key) ? prefs.getInt(key) : null;
+  }
+
+  Future<double?> getDouble(String key) async {
+    final prefs = await _instance;
+    return prefs.containsKey(key) ? prefs.getDouble(key) : null;
+  }
+
+  Future<String?> getString(String key) async {
+    final prefs = await _instance;
+    return prefs.containsKey(key) ? prefs.getString(key) : null;
+  }
+
+  Future<bool> setBool(String key, bool value) async {
+    final prefs = await _instance;
+    return prefs.setBool(key, value);
+  }
+
+  Future<bool> setInt(String key, int value) async {
+    final prefs = await _instance;
+    return prefs.setInt(key, value);
+  }
+
+  Future<bool> setDouble(String key, double value) async {
+    final prefs = await _instance;
+    return prefs.setDouble(key, value);
+  }
+
+  Future<bool> setString(String key, String value) async {
+    final prefs = await _instance;
+    return prefs.setString(key, value);
+  }
+}

--- a/lib/widgets/preferences/about_tab.dart
+++ b/lib/widgets/preferences/about_tab.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:overkeys/widgets/preferences/preference_option_widgets.dart';
+
+class AboutTab extends StatelessWidget {
+  final String appVersion;
+
+  const AboutTab({super.key, required this.appVersion});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SectionTitle(title: 'About'),
+          const SizedBox(height: 20),
+          Image.asset('assets/images/app_icon.png', width: 120),
+          const SizedBox(height: 20),
+          Text('OverKeys',
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 28,
+                  fontWeight: FontWeight.w900)),
+          const SizedBox(height: 20),
+          Text('Version: $appVersion',
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600)),
+          const SizedBox(height: 10),
+          Text('© 2024 Angelo Convento',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withAlpha(153),
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500)),
+          const SizedBox(height: 20),
+          ElevatedButton.icon(
+            onPressed: () async {
+              await launchUrl(
+                  Uri.parse('https://github.com/conventoangelo/overkeys'),
+                  mode: LaunchMode.externalApplication);
+            },
+            icon: ImageIcon(
+              AssetImage('assets/images/github-mark.png'),
+              size: 20,
+            ),
+            label: Text(
+              'View on GitHub',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            style: ElevatedButton.styleFrom(
+              minimumSize: const Size(200, 50),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/preferences/appearance_tab.dart
+++ b/lib/widgets/preferences/appearance_tab.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:overkeys/widgets/preferences/preference_option_widgets.dart';
+
+class AppearanceTab extends StatefulWidget {
+  final double opacity;
+  final Color keyColorPressed;
+  final Color keyColorNotPressed;
+  final Color markerColor;
+  final Color markerColorNotPressed;
+  final double markerOffset;
+  final double markerWidth;
+  final double markerHeight;
+  final double markerBorderRadius;
+  final bool showAltLayout;
+  final Function(double) updateOpacity;
+  final Function(Color) updateKeyColorPressed;
+  final Function(Color) updateKeyColorNotPressed;
+  final Function(Color) updateMarkerColor;
+  final Function(Color) updateMarkerColorNotPressed;
+  final Function(double) updateMarkerOffset;
+  final Function(double) updateMarkerWidth;
+  final Function(double) updateMarkerHeight;
+  final Function(double) updateMarkerBorderRadius;
+
+  const AppearanceTab({
+    super.key,
+    required this.opacity,
+    required this.keyColorPressed,
+    required this.keyColorNotPressed,
+    required this.markerColor,
+    required this.markerColorNotPressed,
+    required this.markerOffset,
+    required this.markerWidth,
+    required this.markerHeight,
+    required this.markerBorderRadius,
+    required this.showAltLayout,
+    required this.updateOpacity,
+    required this.updateKeyColorPressed,
+    required this.updateKeyColorNotPressed,
+    required this.updateMarkerColor,
+    required this.updateMarkerColorNotPressed,
+    required this.updateMarkerOffset,
+    required this.updateMarkerWidth,
+    required this.updateMarkerHeight,
+    required this.updateMarkerBorderRadius,
+  });
+
+  @override
+  State<AppearanceTab> createState() => _AppearanceTabState();
+}
+
+class _AppearanceTabState extends State<AppearanceTab> {
+  late double _localOpacity;
+  late double _localMarkerOffset;
+  late double _localMarkerWidth;
+  late double _localMarkerHeight;
+  late double _localMarkerBorderRadius;
+
+  @override
+  void initState() {
+    super.initState();
+    _localOpacity = widget.opacity;
+    _localMarkerOffset = widget.markerOffset;
+    _localMarkerWidth = widget.markerWidth;
+    _localMarkerHeight = widget.markerHeight;
+    _localMarkerBorderRadius = widget.markerBorderRadius;
+  }
+
+  @override
+  void didUpdateWidget(AppearanceTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.opacity != widget.opacity) {
+      _localOpacity = widget.opacity;
+    }
+    if (oldWidget.markerOffset != widget.markerOffset) {
+      _localMarkerOffset = widget.markerOffset;
+    }
+    if (oldWidget.markerWidth != widget.markerWidth) {
+      _localMarkerWidth = widget.markerWidth;
+    }
+    if (oldWidget.markerHeight != widget.markerHeight) {
+      _localMarkerHeight = widget.markerHeight;
+    }
+    if (oldWidget.markerBorderRadius != widget.markerBorderRadius) {
+      _localMarkerBorderRadius = widget.markerBorderRadius;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SectionTitle(title: 'Appearance Settings'),
+        SliderOption(
+          label: 'Opacity',
+          value: _localOpacity,
+          min: 0.1,
+          max: 1.0,
+          divisions: 18,
+          onChanged: (value) {
+            setState(() => _localOpacity = value);
+          },
+          onChangeEnd: widget.updateOpacity,
+        ),
+        ColorOption(
+          label: 'Key color (pressed)',
+          currentColor: widget.keyColorPressed,
+          onColorChanged: widget.updateKeyColorPressed,
+        ),
+        ColorOption(
+          label: 'Key color (not pressed)',
+          currentColor: widget.keyColorNotPressed,
+          onColorChanged: widget.updateKeyColorNotPressed,
+        ),
+        SectionTitle(title: 'Tactile Markers'),
+        ColorOption(
+          label: 'Marker color (pressed)',
+          currentColor: widget.markerColor,
+          onColorChanged: widget.updateMarkerColor,
+        ),
+        ColorOption(
+          label: 'Marker color (not pressed)',
+          currentColor: widget.markerColorNotPressed,
+          onColorChanged: widget.updateMarkerColorNotPressed,
+        ),
+        SliderOption(
+          label: 'Marker offset',
+          value: _localMarkerOffset,
+          min: 0,
+          max: 20,
+          divisions: 20,
+          onChanged: (value) {
+            setState(() => _localMarkerOffset = value);
+          },
+          onChangeEnd: widget.updateMarkerOffset,
+        ),
+        SliderOption(
+          label: 'Marker width',
+          value: _localMarkerWidth,
+          min: 0,
+          max: 20,
+          divisions: 20,
+          subtitle: widget.showAltLayout
+              ? 'When alternative layout is shown, marker width appear at half the size (width × 0.5)'
+              : null,
+          onChanged: (value) {
+            setState(() => _localMarkerWidth = value);
+          },
+          onChangeEnd: widget.updateMarkerWidth,
+        ),
+        SliderOption(
+          label: 'Marker height',
+          value: _localMarkerHeight,
+          min: 0,
+          max: 10,
+          divisions: 10,
+          subtitle: widget.showAltLayout
+              ? 'When alternative layout is shown, marker height is not used and instead equals the marker width after computation'
+              : null,
+          onChanged: (value) {
+            setState(() => _localMarkerHeight = value);
+          },
+          onChangeEnd: widget.updateMarkerHeight,
+        ),
+        SliderOption(
+          label: 'Marker border radius',
+          value: _localMarkerBorderRadius,
+          min: 0,
+          max: 10,
+          divisions: 10,
+          onChanged: (value) {
+            setState(() => _localMarkerBorderRadius = value);
+          },
+          onChangeEnd: widget.updateMarkerBorderRadius,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/preferences/general_tab.dart
+++ b/lib/widgets/preferences/general_tab.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:overkeys/widgets/preferences/preference_option_widgets.dart';
+import 'package:overkeys/models/keyboard_layouts.dart';
+import 'package:overkeys/services/config_service.dart';
+import 'package:overkeys/models/user_config.dart';
+
+class GeneralTab extends StatefulWidget {
+  final bool launchAtStartup;
+  final bool autoHideEnabled;
+  final double autoHideDuration;
+  final String keyboardLayoutName;
+  final bool enableAdvancedSettings;
+  final bool useUserLayout;
+  final bool showAltLayout;
+  final bool kanataEnabled;
+  final Function(bool) updateLaunchAtStartup;
+  final Function(bool) updateAutoHideEnabled;
+  final Function(double) updateAutoHideDuration;
+  final Function(String) updateKeyboardLayoutName;
+  final Function(bool) updateEnableAdvancedSettings;
+  final Function(bool) updateUseUserLayout;
+  final Function(bool) updateShowAltLayout;
+  final Function(bool) updateKanataEnabled;
+
+  const GeneralTab({
+    super.key,
+    required this.launchAtStartup,
+    required this.autoHideEnabled,
+    required this.autoHideDuration,
+    required this.keyboardLayoutName,
+    required this.enableAdvancedSettings,
+    required this.useUserLayout,
+    required this.showAltLayout,
+    required this.kanataEnabled,
+    required this.updateLaunchAtStartup,
+    required this.updateAutoHideEnabled,
+    required this.updateAutoHideDuration,
+    required this.updateKeyboardLayoutName,
+    required this.updateEnableAdvancedSettings,
+    required this.updateUseUserLayout,
+    required this.updateShowAltLayout,
+    required this.updateKanataEnabled,
+  });
+
+  @override
+  State<GeneralTab> createState() => _GeneralTabState();
+}
+
+class _GeneralTabState extends State<GeneralTab> {
+  late double _localAutoHideDuration;
+
+  @override
+  void initState() {
+    super.initState();
+    _localAutoHideDuration = widget.autoHideDuration;
+  }
+
+  @override
+  void didUpdateWidget(GeneralTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.autoHideDuration != widget.autoHideDuration) {
+      _localAutoHideDuration = widget.autoHideDuration;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SectionTitle(title: 'General Settings'),
+        ToggleOption(
+          label: 'Open on system startup',
+          value: widget.launchAtStartup,
+          onChanged: widget.updateLaunchAtStartup,
+        ),
+        ToggleOption(
+          label: 'Auto-hide keyboard',
+          value: widget.autoHideEnabled,
+          onChanged: widget.updateAutoHideEnabled,
+        ),
+        AnimatedCrossFade(
+          duration: const Duration(milliseconds: 300),
+          firstChild: const SizedBox.shrink(),
+          secondChild: SliderOption(
+            label: 'Auto-hide duration (seconds)',
+            value: _localAutoHideDuration,
+            min: 0.5,
+            max: 5.0,
+            divisions: 9,
+            onChanged: (value) {
+              double roundedValue = (value * 2).round() / 2;
+              setState(() => _localAutoHideDuration = roundedValue);
+            },
+            onChangeEnd: (value) {
+              double roundedValue = (value * 2).round() / 2;
+              widget.updateAutoHideDuration(roundedValue);
+            },
+            valueDisplayFormatter: (value) => value.toStringAsFixed(1),
+          ),
+          crossFadeState: widget.autoHideEnabled
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          sizeCurve: Curves.easeInOut,
+        ),
+        DropdownOption(
+          label: 'Layout',
+          value: widget.keyboardLayoutName,
+          options: availableLayouts.map((layout) => (layout.name)).toList(),
+          onChanged: (value) => widget.updateKeyboardLayoutName(value!),
+        ),
+        ToggleOption(
+          label: 'Turn on advanced settings',
+          value: widget.enableAdvancedSettings,
+          onChanged: widget.updateEnableAdvancedSettings,
+        ),
+        AnimatedCrossFade(
+          duration: const Duration(milliseconds: 300),
+          firstChild: const SizedBox.shrink(),
+          secondChild: Column(
+            children: [
+              ToggleOption(
+                label: 'Use custom layout from config',
+                value: widget.useUserLayout,
+                subtitle:
+                    'Sets layout to user-defined defaultUserLayout. Make sure that the layout is saved in the config file.',
+                onChanged: (value) {
+                  if (value && widget.kanataEnabled) {
+                    widget.updateKanataEnabled(false);
+                  }
+                  widget.updateUseUserLayout(value);
+                },
+              ),
+              ToggleOption(
+                label: 'Show alternative layout',
+                value: widget.showAltLayout,
+                onChanged: widget.updateShowAltLayout,
+              ),
+              ToggleOption(
+                label: 'Connect to Kanata',
+                value: widget.kanataEnabled,
+                subtitle:
+                    'Make sure that Kanata and OverKeys are using the same port. Restart OverKeys if config file changes were made to apply changes.',
+                onChanged: (value) {
+                  if (value && widget.useUserLayout) {
+                    widget.updateUseUserLayout(false);
+                  }
+                  widget.updateKanataEnabled(value);
+                },
+              ),
+              _buildOpenConfigButton(context),
+            ],
+          ),
+          crossFadeState: widget.enableAdvancedSettings
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          sizeCurve: Curves.easeInOut,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOpenConfigButton(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return OptionContainer(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Open config file',
+                    style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16)),
+                Text(
+                  'Turn related advanced setting off then on again to apply changes',
+                  style: TextStyle(
+                      color: colorScheme.onSurface.withAlpha(153),
+                      fontSize: 14.0),
+                  softWrap: true,
+                  overflow: TextOverflow.visible,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          ElevatedButton.icon(
+            icon: Icon(Icons.file_open, color: colorScheme.primary),
+            label: Text('Open',
+                style: TextStyle(
+                  color: colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 16,
+                )),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              elevation: 2,
+              minimumSize: const Size(100, 45),
+              side: BorderSide(color: colorScheme.primary),
+            ),
+            onPressed: () async {
+              try {
+                final configService = ConfigService();
+                final configPath = await configService.configPath;
+                final file = File(configPath);
+
+                if (await file.exists()) {
+                  Process.start('cmd.exe', ['/c', 'start', '', configPath]);
+                } else {
+                  await configService.saveConfig(UserConfig());
+                  Process.start('cmd.exe', ['/c', 'start', '', configPath]);
+                }
+              } catch (e) {
+                debugPrint('Error opening config file: $e');
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/preferences/keyboard_tab.dart
+++ b/lib/widgets/preferences/keyboard_tab.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:overkeys/widgets/preferences/preference_option_widgets.dart';
+
+class KeyboardTab extends StatefulWidget {
+  final String keymapStyle;
+  final bool showTopRow;
+  final bool showGraveKey;
+  final double keySize;
+  final double keyBorderRadius;
+  final double keyPadding;
+  final double spaceWidth;
+  final double splitWidth;
+  final Function(String) updateKeymapStyle;
+  final Function(bool) updateShowTopRow;
+  final Function(bool) updateShowGraveKey;
+  final Function(double) updateKeySize;
+  final Function(double) updateKeyBorderRadius;
+  final Function(double) updateKeyPadding;
+  final Function(double) updateSpaceWidth;
+  final Function(double) updateSplitWidth;
+
+  const KeyboardTab({
+    super.key,
+    required this.keymapStyle,
+    required this.showTopRow,
+    required this.showGraveKey,
+    required this.keySize,
+    required this.keyBorderRadius,
+    required this.keyPadding,
+    required this.spaceWidth,
+    required this.splitWidth,
+    required this.updateKeymapStyle,
+    required this.updateShowTopRow,
+    required this.updateShowGraveKey,
+    required this.updateKeySize,
+    required this.updateKeyBorderRadius,
+    required this.updateKeyPadding,
+    required this.updateSpaceWidth,
+    required this.updateSplitWidth,
+  });
+
+  @override
+  State<KeyboardTab> createState() => _KeyboardTabState();
+}
+
+class _KeyboardTabState extends State<KeyboardTab> {
+  late double _localSpaceWidth;
+  late double _localKeySize;
+  late double _localKeyBorderRadius;
+  late double _localKeyPadding;
+  late double _localSplitWidth;
+
+  @override
+  void initState() {
+    super.initState();
+    _localSpaceWidth = widget.spaceWidth;
+    _localKeySize = widget.keySize;
+    _localKeyBorderRadius = widget.keyBorderRadius;
+    _localKeyPadding = widget.keyPadding;
+    _localSplitWidth = widget.splitWidth;
+  }
+
+  @override
+  void didUpdateWidget(KeyboardTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.spaceWidth != widget.spaceWidth) {
+      _localSpaceWidth = widget.spaceWidth;
+    }
+    if (oldWidget.keySize != widget.keySize) {
+      _localKeySize = widget.keySize;
+    }
+    if (oldWidget.keyBorderRadius != widget.keyBorderRadius) {
+      _localKeyBorderRadius = widget.keyBorderRadius;
+    }
+    if (oldWidget.keyPadding != widget.keyPadding) {
+      _localKeyPadding = widget.keyPadding;
+    }
+    if (oldWidget.splitWidth != widget.splitWidth) {
+      _localSplitWidth = widget.splitWidth;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SectionTitle(title: 'Keyboard Layout'),
+        DropdownOption(
+          label: 'Keymap style',
+          value: widget.keymapStyle,
+          options: ['Staggered', 'Matrix', 'Split Matrix'],
+          onChanged: (value) {
+            if (value == 'Split Matrix' && _localSpaceWidth > 300) {
+              setState(() => _localSpaceWidth = 220.0);
+            }
+            widget.updateKeymapStyle(value!);
+          },
+        ),
+        ToggleOption(
+          label: 'Show top row',
+          value: widget.showTopRow,
+          subtitle:
+              'Recommended to toggle when keyboard is visible or auto-hide is off. Toggling while hidden may cause rendering errors.',
+          onChanged: widget.updateShowTopRow,
+        ),
+        AnimatedCrossFade(
+          duration: const Duration(milliseconds: 300),
+          firstChild: const SizedBox.shrink(),
+          secondChild: ToggleOption(
+            label: 'Show grave key',
+            value: widget.showGraveKey,
+            onChanged: widget.updateShowGraveKey,
+          ),
+          crossFadeState: widget.showTopRow
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          sizeCurve: Curves.easeInOut,
+        ),
+        SectionTitle(title: 'Key Dimensions'),
+        AnimatedCrossFade(
+          duration: const Duration(milliseconds: 300),
+          firstChild: const SizedBox.shrink(),
+          secondChild: SliderOption(
+            label: 'Split width',
+            value: _localSplitWidth,
+            min: 30,
+            max: 200,
+            divisions: 34,
+            onChanged: (value) {
+              setState(() => _localSplitWidth = value);
+            },
+            onChangeEnd: widget.updateSplitWidth,
+          ),
+          crossFadeState: widget.keymapStyle == 'Split Matrix'
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          sizeCurve: Curves.easeInOut,
+        ),
+        SliderOption(
+          label: 'Key size',
+          value: _localKeySize,
+          min: 40,
+          max: 60,
+          divisions: 40,
+          onChanged: (value) {
+            setState(() => _localKeySize = value);
+          },
+          onChangeEnd: widget.updateKeySize,
+        ),
+        SliderOption(
+          label: 'Key border radius',
+          value: _localKeyBorderRadius,
+          min: 0,
+          max: 30,
+          divisions: 30,
+          onChanged: (value) {
+            setState(() => _localKeyBorderRadius = value);
+          },
+          onChangeEnd: widget.updateKeyBorderRadius,
+        ),
+        SliderOption(
+          label: 'Key padding',
+          value: _localKeyPadding,
+          min: 0,
+          max: 10,
+          divisions: 20,
+          onChanged: (value) {
+            setState(() => _localKeyPadding = value);
+          },
+          onChangeEnd: widget.updateKeyPadding,
+        ),
+        SliderOption(
+          label: 'Space width',
+          value: _localSpaceWidth,
+          min: 120,
+          max: (widget.keymapStyle == 'Split Matrix') ? 300 : 500,
+          divisions: (widget.keymapStyle == 'Split Matrix') ? 90 : 190,
+          onChanged: (value) {
+            setState(() => _localSpaceWidth = value);
+          },
+          onChangeEnd: widget.updateSpaceWidth,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/preferences/preference_option_widgets.dart
+++ b/lib/widgets/preferences/preference_option_widgets.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/material.dart';
+import 'package:flex_color_picker/flex_color_picker.dart';
+
+class OptionContainer extends StatelessWidget {
+  final Widget child;
+
+  const OptionContainer({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: child,
+    );
+  }
+}
+
+class SectionTitle extends StatelessWidget {
+  final String title;
+
+  const SectionTitle({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Text(
+        title,
+        style: TextStyle(
+            color: colorScheme.onSurface,
+            fontSize: 20,
+            fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}
+
+class ToggleOption extends StatelessWidget {
+  final String label;
+  final bool value;
+  final Function(bool) onChanged;
+  final String? subtitle;
+
+  const ToggleOption({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    const WidgetStateProperty<Icon> thumbIcon =
+        WidgetStateProperty<Icon>.fromMap(
+      <WidgetStatesConstraint, Icon>{
+        WidgetState.selected: Icon(Icons.check),
+        WidgetState.any: Icon(Icons.close),
+      },
+    );
+    return OptionContainer(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label,
+                    style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16)),
+                if (subtitle != null)
+                  Text(
+                    subtitle!,
+                    style: TextStyle(
+                        color: colorScheme.onSurface.withAlpha(153),
+                        fontSize: 14.0),
+                    softWrap: true,
+                    overflow: TextOverflow.visible,
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          Switch(
+            thumbIcon: thumbIcon,
+            value: value,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class DropdownOption extends StatelessWidget {
+  final String label;
+  final String value;
+  final List<String> options;
+  final Function(String?) onChanged;
+  final String? subtitle;
+
+  const DropdownOption({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.options,
+    required this.onChanged,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final TextEditingController controller = TextEditingController(text: value);
+
+    return OptionContainer(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label,
+                    style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16)),
+                if (subtitle != null)
+                  Text(
+                    subtitle!,
+                    style: TextStyle(
+                        color: colorScheme.onSurface.withAlpha(153),
+                        fontSize: 14.0),
+                    softWrap: true,
+                    overflow: TextOverflow.visible,
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 40),
+          DropdownMenu<String>(
+            controller: controller,
+            initialSelection: value,
+            requestFocusOnTap: true,
+            enableFilter: true,
+            width: 210,
+            menuHeight: 300,
+            dropdownMenuEntries: options
+                .map((String option) => DropdownMenuEntry<String>(
+                      value: option,
+                      label: option,
+                      style: MenuItemButton.styleFrom(
+                        textStyle: TextStyle(
+                          fontFamily: option,
+                          fontFamilyFallback: const ['Manrope'],
+                          fontSize: 15,
+                        ),
+                      ),
+                    ))
+                .toList(),
+            onSelected: (String? newValue) {
+              if (newValue != null) {
+                onChanged(newValue);
+              }
+            },
+            textStyle: TextStyle(
+              fontFamily: value,
+              fontFamilyFallback: const ['Manrope'],
+              fontSize: 15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class SliderOption extends StatelessWidget {
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final Function(double) onChanged;
+  final Function(double) onChangeEnd;
+  final String Function(double)? valueDisplayFormatter;
+  final String? subtitle;
+
+  const SliderOption({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.onChanged,
+    required this.onChangeEnd,
+    this.valueDisplayFormatter,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return OptionContainer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16)),
+          if (subtitle != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+              child: Text(
+                subtitle!,
+                style: TextStyle(
+                    color: colorScheme.onSurface.withAlpha(153),
+                    fontSize: 14.0),
+                softWrap: true,
+                overflow: TextOverflow.visible,
+              ),
+            )
+          else
+            const SizedBox(height: 8.0),
+          Slider(
+            value: value,
+            min: min,
+            divisions: divisions,
+            label: valueDisplayFormatter != null
+                ? valueDisplayFormatter!(value)
+                : value.toStringAsFixed(2),
+            max: max,
+            onChanged: onChanged,
+            onChangeEnd: onChangeEnd,
+            // ignore: deprecated_member_use
+            year2023: false,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ColorOption extends StatelessWidget {
+  final String label;
+  final Color currentColor;
+  final Function(Color) onColorChanged;
+
+  const ColorOption({
+    super.key,
+    required this.label,
+    required this.currentColor,
+    required this.onColorChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return OptionContainer(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16)),
+          ColorIndicator(
+            width: 44,
+            height: 44,
+            borderRadius: 11,
+            color: currentColor,
+            onSelectFocus: false,
+            onSelect: () async {
+              final Color? newColor = await showDialog<Color>(
+                context: context,
+                builder: (BuildContext context) {
+                  Color pickerColor = currentColor;
+                  return AlertDialog(
+                    backgroundColor: colorScheme.surface,
+                    content: SingleChildScrollView(
+                      child: ColorPicker(
+                        wheelDiameter: 250,
+                        wheelWidth: 22,
+                        wheelSquarePadding: 4,
+                        wheelSquareBorderRadius: 16,
+                        wheelHasBorder: true,
+                        color: pickerColor,
+                        onColorChanged: (Color color) {
+                          pickerColor = color;
+                        },
+                        heading: Text(
+                          'Select color',
+                          style: TextStyle(
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                        showColorName: true,
+                        showColorCode: true,
+                        copyPasteBehavior: const ColorPickerCopyPasteBehavior(
+                          copyButton: true,
+                          pasteButton: true,
+                          ctrlC: true,
+                          ctrlV: true,
+                        ),
+                        colorNameTextStyle:
+                            TextStyle(color: colorScheme.onSurface),
+                        colorCodeTextStyle:
+                            TextStyle(color: colorScheme.onSurface),
+                        pickersEnabled: const <ColorPickerType, bool>{
+                          ColorPickerType.primary: false,
+                          ColorPickerType.accent: false,
+                          ColorPickerType.wheel: true,
+                        },
+                      ),
+                    ),
+                    actions: <Widget>[
+                      TextButton(
+                        child: Text('Cancel',
+                            style: TextStyle(color: colorScheme.primary)),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                      TextButton(
+                        child: Text('OK',
+                            style: TextStyle(color: colorScheme.primary)),
+                        onPressed: () {
+                          Navigator.of(context).pop(pickerColor);
+                        },
+                      ),
+                    ],
+                  );
+                },
+              );
+              if (newColor != null) {
+                onColorChanged(newColor);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/preferences/text_tab.dart
+++ b/lib/widgets/preferences/text_tab.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:overkeys/widgets/preferences/preference_option_widgets.dart';
+
+class TextTab extends StatefulWidget {
+  final String fontFamily;
+  final double keyFontSize;
+  final double spaceFontSize;
+  final FontWeight fontWeight;
+  final Color keyTextColor;
+  final Color keyTextColorNotPressed;
+  final Function(String) updateFontFamily;
+  final Function(double) updateKeyFontSize;
+  final Function(double) updateSpaceFontSize;
+  final Function(FontWeight) updateFontWeight;
+  final Function(Color) updateKeyTextColor;
+  final Function(Color) updateKeyTextColorNotPressed;
+
+  const TextTab({
+    super.key,
+    required this.fontFamily,
+    required this.keyFontSize,
+    required this.spaceFontSize,
+    required this.fontWeight,
+    required this.keyTextColor,
+    required this.keyTextColorNotPressed,
+    required this.updateFontFamily,
+    required this.updateKeyFontSize,
+    required this.updateSpaceFontSize,
+    required this.updateFontWeight,
+    required this.updateKeyTextColor,
+    required this.updateKeyTextColorNotPressed,
+  });
+
+  @override
+  State<TextTab> createState() => _TextTabState();
+}
+
+class _TextTabState extends State<TextTab> {
+  late double _localKeyFontSize;
+  late double _localSpaceFontSize;
+
+  @override
+  void initState() {
+    super.initState();
+    _localKeyFontSize = widget.keyFontSize;
+    _localSpaceFontSize = widget.spaceFontSize;
+  }
+
+  @override
+  void didUpdateWidget(TextTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.keyFontSize != widget.keyFontSize) {
+      _localKeyFontSize = widget.keyFontSize;
+    }
+    if (oldWidget.spaceFontSize != widget.spaceFontSize) {
+      _localSpaceFontSize = widget.spaceFontSize;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SectionTitle(title: 'Text Settings'),
+        DropdownOption(
+            label: 'Font style',
+            value: widget.fontFamily,
+            options: [
+              'Berkeley Mono',
+              'Cascadia Mono',
+              'Comic Mono',
+              'CommitMono',
+              'Consolas',
+              'Courier',
+              'Cousine',
+              'Dank Mono',
+              'DM Mono',
+              'Droid Sans Mono',
+              'Fira Code',
+              'Fira Mono',
+              'Geist',
+              'GeistMono',
+              'Google Sans',
+              'Hack',
+              'IBM Plex Mono',
+              'Inconsolata',
+              'Input',
+              'Inter',
+              'Iosevka',
+              'JetBrains Mono',
+              'Manrope',
+              'Meslo',
+              'Monaspace Argon',
+              'Monaspace Krypton',
+              'Monaspace Neon',
+              'Monaspace Radon',
+              'Monaspace Xenon',
+              'Monocraft',
+              'MonoLisa',
+              'mononoki',
+              'Montserrat',
+              'Nunito',
+              'Poppins',
+              'Roboto',
+              'Roboto Mono',
+              'Source Code Pro',
+              'Source Sans Pro',
+              'Ubuntu',
+              'Ubuntu Mono',
+              'Victor Mono',
+            ],
+            onChanged: (value) => widget.updateFontFamily(value!),
+            subtitle:
+                'Make sure that the font is installed in your system. Falls back to Geist Mono.'),
+        SliderOption(
+          label: 'Key font size',
+          value: _localKeyFontSize,
+          min: 12,
+          max: 32,
+          divisions: 40,
+          onChanged: (value) {
+            setState(() => _localKeyFontSize = value);
+          },
+          onChangeEnd: widget.updateKeyFontSize,
+        ),
+        SliderOption(
+          label: 'Space font size',
+          value: _localSpaceFontSize,
+          min: 12,
+          max: 32,
+          divisions: 40,
+          onChanged: (value) {
+            setState(() => _localSpaceFontSize = value);
+          },
+          onChangeEnd: widget.updateSpaceFontSize,
+        ),
+        DropdownOption(
+          label: 'Font weight',
+          value: widget.fontWeight == FontWeight.w100
+              ? 'Thin'
+              : widget.fontWeight == FontWeight.w200
+                  ? 'ExtraLight'
+                  : widget.fontWeight == FontWeight.w300
+                      ? 'Light'
+                      : widget.fontWeight == FontWeight.normal
+                          ? 'Normal'
+                          : widget.fontWeight == FontWeight.w500
+                              ? 'Medium'
+                              : widget.fontWeight == FontWeight.w600
+                                  ? 'SemiBold'
+                                  : widget.fontWeight == FontWeight.bold
+                                      ? 'Bold'
+                                      : widget.fontWeight == FontWeight.w800
+                                          ? 'ExtraBold'
+                                          : 'Black',
+          options: [
+            'Thin',
+            'ExtraLight',
+            'Light',
+            'Normal',
+            'Medium',
+            'SemiBold',
+            'Bold',
+            'ExtraBold',
+            'Black'
+          ],
+          onChanged: (value) {
+            FontWeight weight;
+            switch (value) {
+              case 'Thin':
+                weight = FontWeight.w100;
+                break;
+              case 'ExtraLight':
+                weight = FontWeight.w200;
+                break;
+              case 'Light':
+                weight = FontWeight.w300;
+                break;
+              case 'Normal':
+                weight = FontWeight.normal;
+                break;
+              case 'Medium':
+                weight = FontWeight.w500;
+                break;
+              case 'SemiBold':
+                weight = FontWeight.w600;
+                break;
+              case 'Bold':
+                weight = FontWeight.bold;
+                break;
+              case 'ExtraBold':
+                weight = FontWeight.w800;
+                break;
+              case 'Black':
+                weight = FontWeight.w900;
+                break;
+              default:
+                weight = FontWeight.w500;
+            }
+            widget.updateFontWeight(weight);
+          },
+        ),
+        ColorOption(
+          label: 'Text color (pressed)',
+          currentColor: widget.keyTextColor,
+          onColorChanged: widget.updateKeyTextColor,
+        ),
+        ColorOption(
+          label: 'Text color (not pressed)',
+          currentColor: widget.keyTextColorNotPressed,
+          onColorChanged: widget.updateKeyTextColorNotPressed,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new preferences management system and user interface components to the application. The changes include the implementation of a `PreferencesService` class for managing application settings, and the addition of new tabs in the preferences UI for appearance and about information.

### Preferences Management:
* [`lib/services/preferences_service.dart`](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R1-R276): Added the `PreferencesService` class to manage application settings using `SharedPreferencesAsync`. This class includes methods to get and set various settings such as general, appearance, keyboard, and text settings.

### UI Components:
* [`lib/widgets/preferences/about_tab.dart`](diffhunk://#diff-5a28a0dc2004a160a972936fd38d0b165b4cdda108ab12a17712287d621b324eR1-R69): Added the `AboutTab` widget, which displays information about the application, including the version number and a link to the GitHub repository.
* [`lib/widgets/preferences/appearance_tab.dart`](diffhunk://#diff-89ab45b39104ce89675cc089ffb1d1a0a0010f18e3a15651c346f8d26fad0673R1-R180): Added the `AppearanceTab` widget, which allows users to adjust appearance-related settings such as opacity, key colors, and marker properties.