### PR TITLE
fix: tray menu, window logic, and UI fixes

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -25,7 +25,7 @@ class MainApp extends StatefulWidget {
   State<MainApp> createState() => _MainAppState();
 }
 
-class _MainAppState extends State<MainApp> with TrayListener {
+class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   static const double _defaultWindowWidth = 1000;
   static const double _defaultWindowHeight = 330;
   static const double _defaultTopRowExtraHeight = 80;
@@ -109,6 +109,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
   Future<void> _initialize() async {
     await _loadAllPreferences();
     trayManager.addListener(this);
+    windowManager.addListener(this);
     _setupTray();
     _setupKeyListener();
     _setupHotKeys();
@@ -136,6 +137,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
 
   @override
   void dispose() {
+    windowManager.removeListener(this);
     trayManager.removeListener(this);
     unhook();
     _autoHideTimer?.cancel();
@@ -340,15 +342,12 @@ class _MainAppState extends State<MainApp> with TrayListener {
       _opacity = 0.0;
       _isWindowVisible = false;
     });
-    windowManager.blur();
   }
 
   void _fadeIn() {
-    windowManager.blur().then((_) {
-      setState(() {
-        _isWindowVisible = true;
-        _opacity = _lastOpacity;
-      });
+    setState(() {
+      _isWindowVisible = true;
+      _opacity = _lastOpacity;
     });
     _resetAutoHideTimer();
   }
@@ -579,6 +578,11 @@ class _MainAppState extends State<MainApp> with TrayListener {
       // ignore: deprecated_member_use
       bringAppToFront: true,
     );
+  }
+
+  @override
+  void onWindowFocus() {
+    windowManager.blur();
   }
 
   Future<void> _showPreferences() async {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -520,24 +520,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
               'Visibility hotkey triggered: ${hotKey.toJson()} - toggling force hide to ${!_forceHide}');
         }
         setState(() {
-          _forceHide = !_forceHide;
-          if (_autoHideEnabled && _forceHide) {
-            autoHideBeforeForceHide = _autoHideEnabled;
-            _autoHideEnabled = false;
-            _autoHideTimer?.cancel();
-            if (_isWindowVisible) {
-              _fadeOut();
-            }
-          } else if (autoHideBeforeForceHide && !_forceHide) {
-            _autoHideEnabled = autoHideBeforeForceHide;
-            autoHideBeforeForceHide = false;
-            if (_autoHideEnabled) {
-              _fadeIn();
-              _resetAutoHideTimer();
-            }
-          } else {
-            onTrayIconMouseDown();
-          }
+          onTrayIconMouseDown();
         });
       },
     );
@@ -565,10 +548,27 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   @override
   void onTrayIconMouseDown() {
-    if (_isWindowVisible) {
-      _fadeOut();
+    _forceHide = !_forceHide;
+    if (_autoHideEnabled && _forceHide) {
+      autoHideBeforeForceHide = _autoHideEnabled;
+      _autoHideEnabled = false;
+      _autoHideTimer?.cancel();
+      if (_isWindowVisible) {
+        _fadeOut();
+      }
+    } else if (autoHideBeforeForceHide && !_forceHide) {
+      _autoHideEnabled = autoHideBeforeForceHide;
+      autoHideBeforeForceHide = false;
+      if (_autoHideEnabled) {
+        _fadeIn();
+        _resetAutoHideTimer();
+      }
     } else {
-      _fadeIn();
+      if (_isWindowVisible) {
+        _fadeOut();
+      } else {
+        _fadeIn();
+      }
     }
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -575,7 +575,10 @@ class _MainAppState extends State<MainApp> with TrayListener {
 
   @override
   void onTrayIconRightMouseDown() {
-    trayManager.popUpContextMenu();
+    trayManager.popUpContextMenu(
+      // ignore: deprecated_member_use
+      bringAppToFront: true,
+    );
   }
 
   Future<void> _showPreferences() async {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -587,12 +587,34 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   Future<void> _showPreferences() async {
     try {
+      List<int> windowIds = await DesktopMultiWindow.getAllSubWindowIds();
+      for (int id in windowIds) {
+        Map<String, dynamic>? windowData;
+        try {
+          String? dataString =
+              await DesktopMultiWindow.invokeMethod(id, 'getWindowType');
+          if (dataString != null) {
+            windowData = jsonDecode(dataString);
+            if (windowData != null && windowData['type'] == 'preferences') {
+              await WindowController.fromWindowId(id).show();
+              await DesktopMultiWindow.invokeMethod(id, 'requestFocus');
+              return;
+            }
+          }
+        } catch (e) {
+          if (kDebugMode) {
+            print('Error getting window data: $e');
+          }
+        }
+      }
+
       await DesktopMultiWindow.createWindow(jsonEncode({
+        'type': 'preferences',
         'name': 'preferences',
       }));
     } catch (e) {
       if (kDebugMode) {
-        print('Error creating preferences window: $e');
+        print('Error handling preferences window: $e');
       }
     }
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -430,6 +430,7 @@ class _MainAppState extends State<MainApp> with TrayListener {
             id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
       }
     });
+    _saveAllPreferences();
     _setupTray();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,6 +65,7 @@ void main(List<String> args) async {
       await windowManager.setSize(Size(windowWidth, windowHeight));
       await windowManager.setIgnoreMouseEvents(true);
       await windowManager.setAlignment(Alignment.bottomCenter);
+      await windowManager.setSkipTaskbar(true);
       await windowManager.show();
     });
 

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -125,9 +125,17 @@ class _PreferencesScreenState extends State<PreferencesScreen>
 
   void _setupMethodHandler() {
     DesktopMultiWindow.setMethodHandler((call, fromWindowId) async {
+      if (call.method == 'getWindowType') {
+        return jsonEncode({'type': 'preferences'});
+      }
+
       if (call.method == 'updateAutoHideFromMainWindow' && mounted) {
         setState(() => _autoHideEnabled = call.arguments as bool);
         await _prefsService.setAutoHideEnabled(_autoHideEnabled);
+      }
+
+      if (call.method == 'requestFocus') {
+        await windowManager.focus();
       }
       return null;
     });

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -7,13 +7,13 @@
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
-
-  HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"single_instance_example");
+  HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"OverKeys");
   if (hwnd != NULL) {
     ::ShowWindow(hwnd, SW_NORMAL);
     ::SetForegroundWindow(hwnd);
     return EXIT_FAILURE;
   }
+
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {


### PR DESCRIPTION
This pull request includes several updates and improvements to the `lib/app.dart`, `lib/main.dart`, `lib/screens/preferences_screen.dart`, and `windows/runner/main.cpp` files. The changes primarily focus on enhancing window management and handling user interactions more effectively.

### Enhancements to Window Management:

* Added `WindowListener` mixin to `_MainAppState` and registered/unregistered the listener in `_initialize` and `dispose` methods. (`lib/app.dart`) [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL28-R28) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR112) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR140)
* Implemented the `onWindowFocus` method to blur the window when it gains focus. (`lib/app.dart`)
* Set the window to skip the taskbar using `windowManager.setSkipTaskbar(true)`. (`lib/main.dart`)

### User Interaction Improvements:

* Moved the logic for handling force hide and auto-hide from the hotkey handler to `onTrayIconMouseDown` for better separation of concerns. (`lib/app.dart`) [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL523-L540) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR551-R617)
* Updated the `onTrayIconRightMouseDown` method to bring the app to the front when the context menu is shown. (`lib/app.dart`)

### Preferences Window Handling:

* Added methods to handle preferences window focus and visibility, ensuring the preferences window is brought to the front if it already exists. (`lib/app.dart`, `lib/screens/preferences_screen.dart`) [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR551-R617) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R128-R139)

### Miscellaneous:

* Changed the window class name in `windows/runner/main.cpp` to "OverKeys" to ensure the correct window is targeted. (`windows/runner/main.cpp`)