### PR TITLE
feat: add key borders to improve key visibility

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -63,6 +63,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   double _spaceWidth = 320;
   double _splitWidth = 100;
   double _lastRowSplitWidth = 100;
+  double _keyBorderThickness = 0;
 
   // Text settings
   String _fontFamily = 'GeistMono';
@@ -84,6 +85,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   Color _markerColorNotPressed = Colors.black;
   Color _keyTextColor = Colors.white;
   Color _keyTextColorNotPressed = Colors.black;
+  Color _keyBorderColorPressed = Colors.black;
+  Color _keyBorderColorNotPressed = Colors.white;
 
   // Animations settings
   bool _animationEnabled = false;
@@ -197,6 +200,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       _spaceWidth = prefs['spaceWidth'];
       _splitWidth = prefs['splitWidth'];
       _lastRowSplitWidth = prefs['lastRowSplitWidth'];
+      _keyBorderThickness = prefs['keyBorderThickness'];
 
       // Text settings
       _fontFamily = prefs['fontFamily'];
@@ -217,6 +221,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       _markerColorNotPressed = prefs['markerColorNotPressed'];
       _keyTextColor = prefs['keyTextColor'];
       _keyTextColorNotPressed = prefs['keyTextColorNotPressed'];
+      _keyBorderColorPressed = prefs['keyBorderColorPressed'];
+      _keyBorderColorNotPressed = prefs['keyBorderColorNotPressed'];
 
       // Animations settings
       _animationEnabled = prefs['animationEnabled'];
@@ -259,6 +265,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       'spaceWidth': _spaceWidth,
       'splitWidth': _splitWidth,
       'lastRowSplitWidth': _lastRowSplitWidth,
+      'keyBorderThickness': _keyBorderThickness,
 
       // Text settings
       'fontFamily': _fontFamily,
@@ -279,6 +286,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       'markerColorNotPressed': _markerColorNotPressed,
       'keyTextColor': _keyTextColor,
       'keyTextColorNotPressed': _keyTextColorNotPressed,
+      'keyBorderColorPressed': _keyBorderColorPressed,
+      'keyBorderColorNotPressed': _keyBorderColorNotPressed,
 
       // Animations settings
       'animationEnabled': _animationEnabled,
@@ -715,7 +724,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         case 'updateLayout':
           final layoutName = call.arguments as String;
           setState(() {
-            if ((_kanataEnabled || _useUserLayout) && _advancedSettingsEnabled) {
+            if ((_kanataEnabled || _useUserLayout) &&
+                _advancedSettingsEnabled) {
               _initialKeyboardLayout = availableLayouts
                   .firstWhere((layout) => layout.name == layoutName);
             } else {
@@ -755,6 +765,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         case 'updateLastRowSplitWidth':
           final lastRowSplitWidth = call.arguments as double;
           setState(() => _lastRowSplitWidth = lastRowSplitWidth);
+        case 'updateKeyBorderThickness':
+          final keyBorderThickness = call.arguments as double;
+          setState(() => _keyBorderThickness = keyBorderThickness);
 
         // Text settings
         case 'updateFontFamily':
@@ -810,6 +823,13 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
           final keyTextColorNotPressed = call.arguments as int;
           setState(
               () => _keyTextColorNotPressed = Color(keyTextColorNotPressed));
+        case 'updateKeyBorderColorPressed':
+          final keyBorderColorPressed = call.arguments as int;
+          setState(() => _keyBorderColorPressed = Color(keyBorderColorPressed));
+        case 'updateKeyBorderColorNotPressed':
+          final keyBorderColorNotPressed = call.arguments as int;
+          setState(() =>
+              _keyBorderColorNotPressed = Color(keyBorderColorNotPressed));
 
         // Animations settings
         case 'updateAnimationEnabled':
@@ -973,19 +993,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
                   color: Colors.transparent,
                   child: Center(
                     child: KeyboardScreen(
-                      keyPressStates: _keyPressStates,
                       layout: _keyboardLayout,
-                      showAltLayout: _advancedSettingsEnabled && _showAltLayout,
-                      altLayout: _altLayout,
-                      use6ColLayout: _use6ColLayout,
-                      keyColorPressed: _keyColorPressed,
-                      keyColorNotPressed: _keyColorNotPressed,
-                      markerColor: _markerColor,
-                      markerColorNotPressed: _markerColorNotPressed,
-                      markerOffset: _markerOffset,
-                      markerWidth: _markerWidth,
-                      markerHeight: _markerHeight,
-                      markerBorderRadius: _markerBorderRadius,
                       keymapStyle: _keymapStyle,
                       showTopRow: _showTopRow,
                       showGraveKey: _showGraveKey,
@@ -995,15 +1003,30 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
                       spaceWidth: _spaceWidth,
                       splitWidth: _splitWidth,
                       lastRowSplitWidth: _lastRowSplitWidth,
+                      keyBorderThickness: _keyBorderThickness,
                       keyFontSize: _keyFontSize,
                       spaceFontSize: _spaceFontSize,
                       fontWeight: _fontWeight,
+                      markerOffset: _markerOffset,
+                      markerWidth: _markerWidth,
+                      markerHeight: _markerHeight,
+                      markerBorderRadius: _markerBorderRadius,
+                      keyColorPressed: _keyColorPressed,
+                      keyColorNotPressed: _keyColorNotPressed,
+                      markerColor: _markerColor,
+                      markerColorNotPressed: _markerColorNotPressed,
                       keyTextColor: _keyTextColor,
                       keyTextColorNotPressed: _keyTextColorNotPressed,
+                      keyBorderColorPressed: _keyBorderColorPressed,
+                      keyBorderColorNotPressed: _keyBorderColorNotPressed,
                       animationEnabled: _animationEnabled,
                       animationStyle: _animationStyle,
                       animationDuration: _animationDuration,
                       animationScale: _animationScale,
+                      showAltLayout: _advancedSettingsEnabled && _showAltLayout,
+                      altLayout: _altLayout,
+                      use6ColLayout: _use6ColLayout,
+                      keyPressStates: _keyPressStates,
                     ),
                   ),
                 ),

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -3,24 +3,13 @@ import '../models/keyboard_layouts.dart';
 import '../models/mappings.dart';
 
 class KeyboardScreen extends StatelessWidget {
-  final Map<String, bool> keyPressStates;
   final KeyboardLayout layout;
-  final bool showAltLayout;
-  final KeyboardLayout? altLayout;
-  final bool use6ColLayout;
-  final Color keyColorPressed;
-  final Color keyColorNotPressed;
-  final Color markerColor;
-  final Color markerColorNotPressed;
-  final double markerOffset;
-  final double markerWidth;
-  final double markerHeight;
-  final double markerBorderRadius;
   final String keymapStyle;
   final bool showTopRow;
   final bool showGraveKey;
   final double keySize;
   final double keyBorderRadius;
+  final double keyBorderThickness;
   final double keyPadding;
   final double spaceWidth;
   final double splitWidth;
@@ -28,46 +17,64 @@ class KeyboardScreen extends StatelessWidget {
   final double keyFontSize;
   final double spaceFontSize;
   final FontWeight fontWeight;
+  final double markerOffset;
+  final double markerWidth;
+  final double markerHeight;
+  final double markerBorderRadius;
+  final Color keyColorPressed;
+  final Color keyColorNotPressed;
+  final Color markerColor;
+  final Color markerColorNotPressed;
   final Color keyTextColor;
   final Color keyTextColorNotPressed;
+  final Color keyBorderColorPressed;
+  final Color keyBorderColorNotPressed;
   final bool animationEnabled;
   final String animationStyle;
   final double animationDuration;
   final double animationScale;
+  final bool showAltLayout;
+  final KeyboardLayout? altLayout;
+  final bool use6ColLayout;
+  final Map<String, bool> keyPressStates;
 
-  const KeyboardScreen(
-      {super.key,
-      required this.keyPressStates,
-      required this.layout,
-      required this.showAltLayout,
-      required this.altLayout,
-      required this.use6ColLayout,
-      required this.keyColorPressed,
-      required this.keyColorNotPressed,
-      required this.markerColor,
-      required this.markerColorNotPressed,
-      required this.markerOffset,
-      required this.markerWidth,
-      required this.markerHeight,
-      required this.markerBorderRadius,
-      required this.keymapStyle,
-      required this.showTopRow,
-      required this.showGraveKey,
-      required this.keySize,
-      required this.keyBorderRadius,
-      required this.keyPadding,
-      required this.spaceWidth,
-      required this.splitWidth,
-      required this.lastRowSplitWidth,
-      required this.keyFontSize,
-      required this.spaceFontSize,
-      required this.fontWeight,
-      required this.keyTextColor,
-      required this.keyTextColorNotPressed,
-      required this.animationEnabled,
-      required this.animationStyle,
-      required this.animationDuration,
-      required this.animationScale});
+  const KeyboardScreen({
+    super.key,
+    required this.layout,
+    required this.keymapStyle,
+    required this.showTopRow,
+    required this.showGraveKey,
+    required this.keySize,
+    required this.keyBorderRadius,
+    required this.keyBorderThickness,
+    required this.keyPadding,
+    required this.spaceWidth,
+    required this.splitWidth,
+    required this.lastRowSplitWidth,
+    required this.keyFontSize,
+    required this.spaceFontSize,
+    required this.fontWeight,
+    required this.markerOffset,
+    required this.markerWidth,
+    required this.markerHeight,
+    required this.markerBorderRadius,
+    required this.keyColorPressed,
+    required this.keyColorNotPressed,
+    required this.markerColor,
+    required this.markerColorNotPressed,
+    required this.keyTextColor,
+    required this.keyTextColorNotPressed,
+    required this.keyBorderColorPressed,
+    required this.keyBorderColorNotPressed,
+    required this.animationEnabled,
+    required this.animationStyle,
+    required this.animationDuration,
+    required this.animationScale,
+    required this.showAltLayout,
+    required this.altLayout,
+    required this.use6ColLayout,
+    required this.keyPressStates,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -162,6 +169,8 @@ class KeyboardScreen extends StatelessWidget {
     Color keyColor = isPressed ? keyColorPressed : keyColorNotPressed;
     Color textColor = isPressed ? keyTextColor : keyTextColorNotPressed;
     Color tactMarkerColor = isPressed ? markerColor : markerColorNotPressed;
+    Color borderColor =
+        isPressed ? keyBorderColorPressed : keyBorderColorNotPressed;
 
     double width = key == " "
         ? spaceWidth
@@ -170,14 +179,20 @@ class KeyboardScreen extends StatelessWidget {
     Widget keyWidget = Padding(
       padding: EdgeInsets.all(keyPadding),
       child: AnimatedContainer(
-        duration: Duration(milliseconds: animationEnabled ? animationDuration.toInt() : 20),
+        duration: Duration(
+            milliseconds: animationEnabled ? animationDuration.toInt() : 20),
         curve: Curves.easeInOutCubic,
         width: width,
         height: keySize,
         decoration: BoxDecoration(
-          color: keyColor,
-          borderRadius: BorderRadius.circular(keyBorderRadius),
-        ),
+            color: keyColor,
+            borderRadius: BorderRadius.circular(keyBorderRadius),
+            border: keyBorderThickness > 0
+                ? Border.all(
+                    color: borderColor,
+                    width: keyBorderThickness,
+                  )
+                : null),
         transform: _getAnimationTransform(isPressed),
         child: key == " "
             ? Center(

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -51,6 +51,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   bool _showGraveKey = false;
   double _keySize = 48;
   double _keyBorderRadius = 12;
+  double _keyBorderThickness = 0;
   double _keyPadding = 3;
   double _spaceWidth = 320;
   double _splitWidth = 100;
@@ -75,6 +76,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   Color _markerColorNotPressed = Colors.black;
   Color _keyTextColor = Colors.white;
   Color _keyTextColorNotPressed = Colors.black;
+  Color _keyBorderColorPressed = Colors.black;
+  Color _keyBorderColorNotPressed = Colors.white;
 
   // Animations settings
   bool _animationEnabled = true;
@@ -175,6 +178,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _showGraveKey = prefs['showGraveKey'];
       _keySize = prefs['keySize'];
       _keyBorderRadius = prefs['keyBorderRadius'];
+      _keyBorderThickness = prefs['keyBorderThickness'];
       _keyPadding = prefs['keyPadding'];
       _spaceWidth = prefs['spaceWidth'];
       _splitWidth = prefs['splitWidth'];
@@ -199,6 +203,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _markerColorNotPressed = prefs['markerColorNotPressed'];
       _keyTextColor = prefs['keyTextColor'];
       _keyTextColorNotPressed = prefs['keyTextColorNotPressed'];
+      _keyBorderColorPressed = prefs['keyBorderColorPressed'];
+      _keyBorderColorNotPressed = prefs['keyBorderColorNotPressed'];
 
       // Animations settings
       _animationEnabled = prefs['animationEnabled'];
@@ -236,6 +242,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       'showGraveKey': _showGraveKey,
       'keySize': _keySize,
       'keyBorderRadius': _keyBorderRadius,
+      'keyBorderThickness': _keyBorderThickness,
       'keyPadding': _keyPadding,
       'spaceWidth': _spaceWidth,
       'splitWidth': _splitWidth,
@@ -260,6 +267,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       'markerColorNotPressed': _markerColorNotPressed,
       'keyTextColor': _keyTextColor,
       'keyTextColorNotPressed': _keyTextColorNotPressed,
+      'keyBorderColorPressed': _keyBorderColorPressed,
+      'keyBorderColorNotPressed': _keyBorderColorNotPressed,
 
       // Animations settings
       'animationEnabled': _animationEnabled,
@@ -480,6 +489,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           spaceWidth: _spaceWidth,
           splitWidth: _splitWidth,
           lastRowSplitWidth: _lastRowSplitWidth,
+          keyBorderThickness: _keyBorderThickness,
           updateKeymapStyle: (value) {
             setState(() => _keymapStyle = value);
             _updateMainWindow('updateKeymapStyle', value);
@@ -515,6 +525,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updateLastRowSplitWidth: (value) {
             setState(() => _lastRowSplitWidth = value);
             _updateMainWindow('updateLastRowSplitWidth', value);
+          },
+          updateKeyBorderThickness: (value) {
+            setState(() => _keyBorderThickness = value);
+            _updateMainWindow('updateKeyBorderThickness', value);
           },
         );
       case 'Text':
@@ -572,6 +586,8 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           markerColorNotPressed: _markerColorNotPressed,
           keyTextColor: _keyTextColor,
           keyTextColorNotPressed: _keyTextColorNotPressed,
+          keyBorderColorPressed: _keyBorderColorPressed,
+          keyBorderColorNotPressed: _keyBorderColorNotPressed,
           updateKeyColorPressed: (value) {
             setState(() => _keyColorPressed = value);
             _updateMainWindow('updateKeyColorPressed', value);
@@ -595,6 +611,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updateKeyTextColorNotPressed: (value) {
             setState(() => _keyTextColorNotPressed = value);
             _updateMainWindow('updateKeyTextColorNotPressed', value);
+          },
+          updateKeyBorderColorPressed: (value) {
+            setState(() => _keyBorderColorPressed = value);
+            _updateMainWindow('updateKeyBorderColorPressed', value);
+          },
+          updateKeyBorderColorNotPressed: (value) {
+            setState(() => _keyBorderColorNotPressed = value);
+            _updateMainWindow('updateKeyBorderColorNotPressed', value);
           },
         );
       case 'Animations':

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -35,6 +35,8 @@ class PreferencesService {
       await _prefs.getDouble('splitWidth') ?? 100;
   Future<double> getLastRowSplitWidth() async =>
       await _prefs.getDouble('lastRowSplitWidth') ?? 100;
+  Future<double> getKeyBorderThickness() async =>
+      await _prefs.getDouble('keyBorderThickness') ?? 0;
 
   // Text settings
   Future<String> getFontFamily() async =>
@@ -69,6 +71,10 @@ class PreferencesService {
       Color(await _prefs.getInt('keyTextColor') ?? 0xFFFFFFFF);
   Future<Color> getKeyTextColorNotPressed() async =>
       Color(await _prefs.getInt('keyTextColorNotPressed') ?? 0xFF000000);
+  Future<Color> getKeyBorderColorPressed() async =>
+      Color(await _prefs.getInt('keyBorderColorPressed') ?? 0xFF000000);
+  Future<Color> getKeyBorderColorNotPressed() async =>
+      Color(await _prefs.getInt('keyBorderColorNotPressed') ?? 0xFFFFFFFF);
 
   // Animations settings
   Future<bool> getAnimationEnabled() async =>
@@ -152,6 +158,8 @@ class PreferencesService {
       await _prefs.setDouble('splitWidth', value);
   Future<void> setLastRowSplitWidth(double value) async =>
       await _prefs.setDouble('lastRowSplitWidth', value);
+  Future<void> setKeyBorderThickness(double value) async =>
+      await _prefs.setDouble('keyBorderThickness', value);
 
   // Text settings
   Future<void> setFontFamily(String value) async =>
@@ -186,6 +194,10 @@ class PreferencesService {
       await _prefs.setInt('keyTextColor', value.toARGB32());
   Future<void> setKeyTextColorNotPressed(Color value) async =>
       await _prefs.setInt('keyTextColorNotPressed', value.toARGB32());
+  Future<void> setKeyBorderColorPressed(Color value) async =>
+      await _prefs.setInt('keyBorderColorPressed', value.toARGB32());
+  Future<void> setKeyBorderColorNotPressed(Color value) async =>
+      await _prefs.setInt('keyBorderColorNotPressed', value.toARGB32());
 
   // Animations settings
   Future<void> setAnimationEnabled(bool value) async =>
@@ -238,6 +250,7 @@ class PreferencesService {
       'spaceWidth': await getSpaceWidth(),
       'splitWidth': await getSplitWidth(),
       'lastRowSplitWidth': await getLastRowSplitWidth(),
+      'keyBorderThickness': await getKeyBorderThickness(),
 
       // Text settings
       'fontFamily': await getFontFamily(),
@@ -258,6 +271,8 @@ class PreferencesService {
       'markerColorNotPressed': await getMarkerColorNotPressed(),
       'keyTextColor': await getKeyTextColor(),
       'keyTextColorNotPressed': await getKeyTextColorNotPressed(),
+      'keyBorderColorPressed': await getKeyBorderColorPressed(),
+      'keyBorderColorNotPressed': await getKeyBorderColorNotPressed(),
 
       // Animations settings
       'animationEnabled': await getAnimationEnabled(),
@@ -298,6 +313,7 @@ class PreferencesService {
     await setSpaceWidth(prefs['spaceWidth']);
     await setSplitWidth(prefs['splitWidth']);
     await setLastRowSplitWidth(prefs['lastRowSplitWidth']);
+    await setKeyBorderThickness(prefs['keyBorderThickness']);
 
     // Text settings
     await setFontFamily(prefs['fontFamily']);
@@ -318,6 +334,8 @@ class PreferencesService {
     await setMarkerColorNotPressed(prefs['markerColorNotPressed']);
     await setKeyTextColor(prefs['keyTextColor']);
     await setKeyTextColorNotPressed(prefs['keyTextColorNotPressed']);
+    await setKeyBorderColorPressed(prefs['keyBorderColorPressed']);
+    await setKeyBorderColorNotPressed(prefs['keyBorderColorNotPressed']);
 
     // Animations settings
     await setAnimationEnabled(prefs['animationEnabled']);

--- a/lib/widgets/tabs/colors_tab.dart
+++ b/lib/widgets/tabs/colors_tab.dart
@@ -8,12 +8,16 @@ class ColorsTab extends StatelessWidget {
   final Color markerColorNotPressed;
   final Color keyTextColor;
   final Color keyTextColorNotPressed;
+  final Color keyBorderColorPressed;
+  final Color keyBorderColorNotPressed;
   final Function(Color) updateKeyColorPressed;
   final Function(Color) updateKeyColorNotPressed;
   final Function(Color) updateMarkerColor;
   final Function(Color) updateMarkerColorNotPressed;
   final Function(Color) updateKeyTextColor;
   final Function(Color) updateKeyTextColorNotPressed;
+  final Function(Color) updateKeyBorderColorPressed;
+  final Function(Color) updateKeyBorderColorNotPressed;
 
   const ColorsTab({
     super.key,
@@ -23,12 +27,16 @@ class ColorsTab extends StatelessWidget {
     required this.markerColorNotPressed,
     required this.keyTextColor,
     required this.keyTextColorNotPressed,
+    required this.keyBorderColorPressed,
+    required this.keyBorderColorNotPressed,
     required this.updateKeyColorPressed,
     required this.updateKeyColorNotPressed,
     required this.updateMarkerColor,
     required this.updateMarkerColorNotPressed,
     required this.updateKeyTextColor,
     required this.updateKeyTextColorNotPressed,
+    required this.updateKeyBorderColorPressed,
+    required this.updateKeyBorderColorNotPressed,
   });
 
   @override
@@ -46,7 +54,6 @@ class ColorsTab extends StatelessWidget {
           currentColor: keyColorNotPressed,
           onColorChanged: updateKeyColorNotPressed,
         ),
-
         ColorOption(
           label: 'Marker color (pressed)',
           currentColor: markerColor,
@@ -57,7 +64,6 @@ class ColorsTab extends StatelessWidget {
           currentColor: markerColorNotPressed,
           onColorChanged: updateMarkerColorNotPressed,
         ),
-
         ColorOption(
           label: 'Text color (pressed)',
           currentColor: keyTextColor,
@@ -67,6 +73,16 @@ class ColorsTab extends StatelessWidget {
           label: 'Text color (not pressed)',
           currentColor: keyTextColorNotPressed,
           onColorChanged: updateKeyTextColorNotPressed,
+        ),
+        ColorOption(
+          label: 'Border color (pressed)',
+          currentColor: keyBorderColorPressed,
+          onColorChanged: updateKeyBorderColorPressed,
+        ),
+        ColorOption(
+          label: 'Border color (not pressed)',
+          currentColor: keyBorderColorNotPressed,
+          onColorChanged: updateKeyBorderColorNotPressed,
         ),
       ],
     );

--- a/lib/widgets/tabs/keyboard_tab.dart
+++ b/lib/widgets/tabs/keyboard_tab.dart
@@ -7,6 +7,7 @@ class KeyboardTab extends StatefulWidget {
   final bool showGraveKey;
   final double keySize;
   final double keyBorderRadius;
+  final double keyBorderThickness;
   final double keyPadding;
   final double spaceWidth;
   final double splitWidth;
@@ -16,6 +17,7 @@ class KeyboardTab extends StatefulWidget {
   final Function(bool) updateShowGraveKey;
   final Function(double) updateKeySize;
   final Function(double) updateKeyBorderRadius;
+  final Function(double) updateKeyBorderThickness;
   final Function(double) updateKeyPadding;
   final Function(double) updateSpaceWidth;
   final Function(double) updateSplitWidth;
@@ -28,6 +30,7 @@ class KeyboardTab extends StatefulWidget {
     required this.showGraveKey,
     required this.keySize,
     required this.keyBorderRadius,
+    required this.keyBorderThickness,
     required this.keyPadding,
     required this.spaceWidth,
     required this.splitWidth,
@@ -37,6 +40,7 @@ class KeyboardTab extends StatefulWidget {
     required this.updateShowGraveKey,
     required this.updateKeySize,
     required this.updateKeyBorderRadius,
+    required this.updateKeyBorderThickness,
     required this.updateKeyPadding,
     required this.updateSpaceWidth,
     required this.updateSplitWidth,
@@ -50,6 +54,7 @@ class KeyboardTab extends StatefulWidget {
 class _KeyboardTabState extends State<KeyboardTab> {
   late double _localKeySize;
   late double _localKeyBorderRadius;
+  late double _localKeyBorderThickness;
   late double _localKeyPadding;
   late double _localSpaceWidth;
   late double _localSplitWidth;
@@ -60,6 +65,7 @@ class _KeyboardTabState extends State<KeyboardTab> {
     super.initState();
     _localKeySize = widget.keySize;
     _localKeyBorderRadius = widget.keyBorderRadius;
+    _localKeyBorderThickness = widget.keyBorderThickness;
     _localKeyPadding = widget.keyPadding;
     _localSpaceWidth = widget.spaceWidth;
     _localSplitWidth = widget.splitWidth;
@@ -74,6 +80,9 @@ class _KeyboardTabState extends State<KeyboardTab> {
     }
     if (oldWidget.keyBorderRadius != widget.keyBorderRadius) {
       _localKeyBorderRadius = widget.keyBorderRadius;
+    }
+    if (oldWidget.keyBorderThickness != widget.keyBorderThickness) {
+      _localKeyBorderThickness = widget.keyBorderThickness;
     }
     if (oldWidget.keyPadding != widget.keyPadding) {
       _localKeyPadding = widget.keyPadding;
@@ -187,6 +196,17 @@ class _KeyboardTabState extends State<KeyboardTab> {
             setState(() => _localKeyBorderRadius = value);
           },
           onChangeEnd: widget.updateKeyBorderRadius,
+        ),
+        SliderOption(
+          label: 'Key border thickness',
+          value: _localKeyBorderThickness,
+          min: 0,
+          max: 5,
+          divisions: 10,
+          onChanged: (value) {
+            setState(() => _localKeyBorderThickness = value);
+          },
+          onChangeEnd: widget.updateKeyBorderThickness,
         ),
         SliderOption(
           label: 'Key padding',


### PR DESCRIPTION
This pull request introduces several changes to the `lib/app.dart`, `lib/screens/keyboard_screen.dart`, `lib/screens/preferences_screen.dart`, and `lib/services/preferences_service.dart` files to add new properties related to key border settings, including thickness and color.

### Key Border Settings Enhancements:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR66): Added new properties `_keyBorderThickness`, `_keyBorderColorPressed`, and `_keyBorderColorNotPressed` to the `_MainAppState` class. Updated the `updateLayout`, `updateLastRowSplitWidth`, and `updateFontFamily` methods to handle these new properties. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR66) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR88-R89) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR203) [[4]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR224-R225) [[5]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR268) [[6]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR289-R290) [[7]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL718-R728) [[8]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR768-R770) [[9]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR826-R832) [[10]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL976-L988) [[11]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR1006-R1029)

* [`lib/screens/keyboard_screen.dart`](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L6-R77): Updated the `KeyboardScreen` class to include new properties for key border settings and adjusted the widget build method to apply these settings. [[1]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L6-R77) [[2]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642R172-R173) [[3]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L173-R195)

### Preferences Screen Updates:

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R54): Added new properties `_keyBorderThickness`, `_keyBorderColorPressed`, and `_keyBorderColorNotPressed` to the `_PreferencesScreenState` class. Updated methods to save and load these preferences. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R54) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R79-R80) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R181) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R206-R207) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R245) [[6]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R270-R271) [[7]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R492) [[8]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R529-R532) [[9]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R589-R590) [[10]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R615-R622)

### Preferences Service Update:

* [`lib/services/preferences_service.dart`](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R38-R39): Added a new method `getKeyBorderThickness` to retrieve the key border thickness preference.