### PR TITLE
feat: add keyboard follows mouse functionality

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -184,11 +184,10 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   void _startMouseTracking() {
     _mouseCheckTimer?.cancel();
-    _mouseCheckTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
-      if (_keyboardFollowsMouse && _advancedSettingsEnabled) {
-        windowManager.setAlignment(Alignment.bottomCenter);
-      }
-    });
+    if (_keyboardFollowsMouse && _advancedSettingsEnabled) {
+      _mouseCheckTimer = Timer.periodic(const Duration(milliseconds: 500),
+          (_) => windowManager.setAlignment(Alignment.bottomCenter));
+    }
   }
 
   void _stopMouseTracking() {
@@ -435,6 +434,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   void _fadeOut() {
+    if (!_isWindowVisible) return;
     setState(() {
       _lastOpacity = _opacity;
       _opacity = 0.0;
@@ -443,7 +443,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   void _fadeIn() {
-    if (_forceHide) return;
+    if (_forceHide || _isWindowVisible) return;
     setState(() {
       _isWindowVisible = true;
       _opacity = _lastOpacity;
@@ -452,7 +452,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   void _setupKeyListener() {
-    ReceivePort receivePort = ReceivePort();
+    final receivePort = ReceivePort();
     Isolate.spawn(setHook, receivePort.sendPort)
         .then((_) {})
         .catchError((error) {
@@ -476,10 +476,10 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
     if (message[0] is! int) return;
 
-    int keyCode = message[0];
-    bool isPressed = message[1];
-    bool isShiftDown = message[2];
-    String key = getKeyFromKeyCodeShift(keyCode, isShiftDown);
+    final keyCode = message[0] as int;
+    final isPressed = message[1] as bool;
+    final isShiftDown = message[2] as bool;
+    final key = getKeyFromKeyCodeShift(keyCode, isShiftDown);
 
     if (kDebugMode) {
       print(
@@ -497,12 +497,12 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   void _resetAutoHideTimer() {
+    if (!_autoHideEnabled) return;
+
     _autoHideTimer?.cancel();
-    if (_autoHideEnabled) {
-      _autoHideTimer = Timer(
-          Duration(milliseconds: (_autoHideDuration * 1000).round()),
-          _handleAutoHide);
-    }
+    _autoHideTimer = Timer(
+        Duration(milliseconds: (_autoHideDuration * 1000).round()),
+        _handleAutoHide);
   }
 
   void _handleAutoHide() {
@@ -551,11 +551,13 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   Future<void> _setupTray() async {
-    String iconPath = Platform.isWindows
+    final String iconPath = Platform.isWindows
         ? 'assets/images/app_icon.ico'
         : 'assets/images/app_icon.png';
-    await trayManager.setIcon(iconPath);
-    trayManager.setToolTip('OverKeys');
+    await Future.wait([
+      trayManager.setIcon(iconPath),
+      trayManager.setToolTip('OverKeys'),
+    ]);
     trayManager.setContextMenu(Menu(items: [
       MenuItem.checkbox(
         key: 'toggle_mouse_events',
@@ -1024,9 +1026,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
               duration: _fadeDuration,
               child: GestureDetector(
                 behavior: HitTestBehavior.translucent,
-                onPanStart: (details) {
-                  windowManager.startDragging();
-                },
+                onPanStart: (_) => windowManager.startDragging(),
                 child: Container(
                   color: Colors.transparent,
                   child: Center(

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -114,6 +114,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   bool _customFontEnabled = false;
   bool _use6ColLayout = false;
   bool _kanataEnabled = false;
+  bool _keyboardFollowsMouse = false;
+  Timer? _mouseCheckTimer;
 
   // Services
   final PreferencesService _prefsService = PreferencesService();
@@ -155,6 +157,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       if (_kanataEnabled) {
         _useKanata();
       }
+      if (_keyboardFollowsMouse) {
+        _startMouseTracking();
+      }
     }
     if (_showTopRow) {
       _adjustWindowSize();
@@ -171,9 +176,23 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     unhook();
     _autoHideTimer?.cancel();
     _overlayTimer?.cancel();
+    _mouseCheckTimer?.cancel();
     _kanataService.dispose();
     _saveAllPreferences();
     super.dispose();
+  }
+
+  void _startMouseTracking() {
+    _mouseCheckTimer?.cancel();
+    _mouseCheckTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
+      if (_keyboardFollowsMouse && _advancedSettingsEnabled) {
+        windowManager.setAlignment(Alignment.bottomCenter);
+      }
+    });
+  }
+
+  void _stopMouseTracking() {
+    _mouseCheckTimer?.cancel();
   }
 
   Future<void> _loadAllPreferences() async {
@@ -243,6 +262,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       _customFontEnabled = prefs['customFontEnabled'];
       _use6ColLayout = prefs['use6ColLayout'];
       _kanataEnabled = prefs['kanataEnabled'];
+      _keyboardFollowsMouse = prefs['keyboardFollowsMouse'] ?? false;
     });
   }
 
@@ -307,6 +327,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       'customFontEnabled': _customFontEnabled,
       'use6ColLayout': _use6ColLayout,
       'kanataEnabled': _kanataEnabled,
+      'keyboardFollowsMouse': _keyboardFollowsMouse,
     };
 
     await _prefsService.saveAllPreferences(prefs);
@@ -883,9 +904,15 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
               if (_customFontEnabled) {
                 _fontFamily = _initialFontFamily;
               }
+              if (_keyboardFollowsMouse) {
+                _stopMouseTracking();
+              }
             } else {
               if (_initialShowAltLayout || _showAltLayout) {
                 _showAltLayout = true;
+              }
+              if (_keyboardFollowsMouse) {
+                _startMouseTracking();
               }
             }
           });
@@ -960,6 +987,17 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
                 _keyboardLayout = _initialKeyboardLayout!;
                 _fadeIn();
               }
+            }
+          });
+        case 'updateKeyboardFollowsMouse':
+          final keyboardFollowsMouse = call.arguments as bool;
+          setState(() {
+            _keyboardFollowsMouse = keyboardFollowsMouse;
+            if (keyboardFollowsMouse && _advancedSettingsEnabled) {
+              _startMouseTracking();
+              windowManager.setAlignment(Alignment.bottomCenter);
+            } else {
+              _stopMouseTracking();
             }
           });
 

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -103,6 +103,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   bool _customFontEnabled = false;
   bool _use6ColLayout = false;
   bool _kanataEnabled = false;
+  bool _keyboardFollowsMouse = false;
 
   @override
   void initState() {
@@ -224,6 +225,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _customFontEnabled = prefs['customFontEnabled'];
       _use6ColLayout = prefs['use6ColLayout'];
       _kanataEnabled = prefs['kanataEnabled'];
+      _keyboardFollowsMouse = prefs['keyboardFollowsMouse'] ?? false;
     });
   }
 
@@ -288,6 +290,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       'customFontEnabled': _customFontEnabled,
       'use6ColLayout': _use6ColLayout,
       'kanataEnabled': _kanataEnabled,
+      'keyboardFollowsMouse': _keyboardFollowsMouse,
     };
 
     await _prefsService.saveAllPreferences(prefs);
@@ -670,6 +673,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           customFontEnabled: _customFontEnabled,
           use6ColLayout: _use6ColLayout,
           kanataEnabled: _kanataEnabled,
+          keyboardFollowsMouse: _keyboardFollowsMouse,
           updateAdvancedSettingsEnabled: (value) {
             setState(() => _advancedSettingsEnabled = value);
             _updateMainWindow('updateAdvancedSettingsEnabled', value);
@@ -701,6 +705,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
               _updateMainWindow('updateUseUserLayout', false);
             }
             _updateMainWindow('updateKanataEnabled', value);
+          },
+          updateKeyboardFollowsMouse: (value) {
+            setState(() => _keyboardFollowsMouse = value);
+            _updateMainWindow('updateKeyboardFollowsMouse', value);
           },
         );
       case 'About':

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -126,6 +126,8 @@ class PreferencesService {
       await _prefs.getBool('use6ColLayout') ?? false;
   Future<bool> getKanataEnabled() async =>
       await _prefs.getBool('kanataEnabled') ?? false;
+  Future<bool> getKeyboardFollowsMouse() async =>
+      await _prefs.getBool('keyboardFollowsMouse') ?? false;
 
   // General settings
   Future<void> setLaunchAtStartup(bool value) async =>
@@ -230,6 +232,8 @@ class PreferencesService {
       await _prefs.setBool('use6ColLayout', value);
   Future<void> setKanataEnabled(bool value) async =>
       await _prefs.setBool('kanataEnabled', value);
+  Future<void> setKeyboardFollowsMouse(bool value) async =>
+      await _prefs.setBool('keyboardFollowsMouse', value);
 
   Future<Map<String, dynamic>> loadAllPreferences() async {
     return {
@@ -292,6 +296,7 @@ class PreferencesService {
       'customFontEnabled': await getCustomFontEnabled(),
       'use6ColLayout': await getUse6ColLayout(),
       'kanataEnabled': await getKanataEnabled(),
+      'keyboardFollowsMouse': await getKeyboardFollowsMouse(),
     };
   }
 
@@ -355,5 +360,6 @@ class PreferencesService {
     await setCustomFontEnabled(prefs['customFontEnabled']);
     await setUse6ColLayout(prefs['use6ColLayout']);
     await setKanataEnabled(prefs['kanataEnabled']);
+    await setKeyboardFollowsMouse(prefs['keyboardFollowsMouse']);
   }
 }

--- a/lib/widgets/tabs/advanced_tab.dart
+++ b/lib/widgets/tabs/advanced_tab.dart
@@ -11,12 +11,14 @@ class AdvancedTab extends StatelessWidget {
   final bool customFontEnabled;
   final bool use6ColLayout;
   final bool kanataEnabled;
+  final bool keyboardFollowsMouse;
   final Function(bool) updateAdvancedSettingsEnabled;
   final Function(bool) updateUseUserLayout;
   final Function(bool) updateShowAltLayout;
   final Function(bool) updateCustomFontEnabled;
   final Function(bool) updateUse6ColLayout;
   final Function(bool) updateKanataEnabled;
+  final Function(bool) updateKeyboardFollowsMouse;
 
   const AdvancedTab({
     super.key,
@@ -26,12 +28,14 @@ class AdvancedTab extends StatelessWidget {
     required this.customFontEnabled,
     required this.use6ColLayout,
     required this.kanataEnabled,
+    required this.keyboardFollowsMouse,
     required this.updateAdvancedSettingsEnabled,
     required this.updateUseUserLayout,
     required this.updateShowAltLayout,
     required this.updateCustomFontEnabled,
     required this.updateUse6ColLayout,
     required this.updateKanataEnabled,
+    required this.updateKeyboardFollowsMouse,
   });
 
   @override
@@ -93,6 +97,13 @@ class AdvancedTab extends StatelessWidget {
                   }
                   updateKanataEnabled(value);
                 },
+              ),
+              ToggleOption(
+                label: 'Keyboard follows mouse',
+                value: keyboardFollowsMouse,
+                subtitle:
+                    'EXPERIMENTAL: Keyboard will follow your mouse cursor across monitors. Note: This will override manual position adjustments.',
+                onChanged: updateKeyboardFollowsMouse,
               ),
               _buildOpenConfigButton(context),
             ],


### PR DESCRIPTION
Temporary(?) solution for multi-monitor users. However, it does not trigger on alt-tab or switch window focus.


This pull request introduces a new feature that allows the keyboard to follow the mouse cursor across monitors. The changes include adding a new preference, updating the UI to reflect this preference, and implementing the functionality to track the mouse and adjust the keyboard position accordingly.

New feature implementation:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR117-R118): Added `_keyboardFollowsMouse` state variable, `_mouseCheckTimer` for periodic mouse tracking, and methods `_startMouseTracking` and `_stopMouseTracking` to manage the tracking. The `dispose` method now cancels `_mouseCheckTimer` if it is running. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR117-R118) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR160-R162) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR179-R197) [[4]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR265) [[5]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR330) [[6]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR907-R916) [[7]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR992-R1002)

Preferences management:

* [`lib/services/preferences_service.dart`](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R129-R130): Added methods to get and set the `keyboardFollowsMouse` preference, and updated `loadAllPreferences` and `saveAllPreferences` to include this new preference. [[1]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R129-R130) [[2]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R235-R236) [[3]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R299) [[4]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R363)

UI updates:

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R106): Added `_keyboardFollowsMouse` state variable and updated the preferences screen to handle this new preference. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R106) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R228) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R293) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R676) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R709-R712)
* [`lib/widgets/tabs/advanced_tab.dart`](diffhunk://#diff-7c798347153017fccb92dd8b20d19431b033f8f99ffc7e62c5bf3356d28e9321R14-R21): Added a toggle option for `keyboardFollowsMouse` in the advanced settings tab. [[1]](diffhunk://#diff-7c798347153017fccb92dd8b20d19431b033f8f99ffc7e62c5bf3356d28e9321R14-R21) [[2]](diffhunk://#diff-7c798347153017fccb92dd8b20d19431b033f8f99ffc7e62c5bf3356d28e9321R31-R38) [[3]](diffhunk://#diff-7c798347153017fccb92dd8b20d19431b033f8f99ffc7e62c5bf3356d28e9321R101-R107)