### PR TITLE
fix: only shrink keys longer than length 2

### DIFF
--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -220,7 +220,7 @@ class KeyboardScreen extends StatelessWidget {
                           textAlign: TextAlign.left,
                           style: TextStyle(
                             color: textColor,
-                            fontSize: key.length > 1
+                            fontSize: key.length > 2
                                 ? keyFontSize * 0.6
                                 : keyFontSize * 0.85,
                             fontWeight: fontWeight,
@@ -237,7 +237,7 @@ class KeyboardScreen extends StatelessWidget {
                           style: TextStyle(
                             color: textColor,
                             fontSize:
-                                _getAltLayoutKey(rowIndex, keyIndex).length > 1
+                                _getAltLayoutKey(rowIndex, keyIndex).length > 2
                                     ? keyFontSize * 0.6
                                     : keyFontSize * 0.85,
                             fontWeight: fontWeight,
@@ -253,7 +253,7 @@ class KeyboardScreen extends StatelessWidget {
                       style: TextStyle(
                         color: textColor,
                         fontSize:
-                            key.length > 1 ? keyFontSize * 0.7 : keyFontSize,
+                            key.length > 2 ? keyFontSize * 0.7 : keyFontSize,
                         fontWeight: fontWeight,
                       ),
                     ),


### PR DESCRIPTION
This pull request includes changes to the `KeyboardScreen` class in the `lib/screens/keyboard_screen.dart` file to adjust the font size logic for keys based on their length.

Font size adjustments for key length:

* Modified the font size condition to check if `key.length` is greater than 2 instead of 1. [[1]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L223-R223) [[2]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L256-R256)
* Updated the font size condition for alternative layout keys to check if `_getAltLayoutKey(rowIndex, keyIndex).length` is greater than 2 instead of 1.