### PR TITLE
fix: update color picker behavior

### DIFF
--- a/lib/widgets/options/color_option.dart
+++ b/lib/widgets/options/color_option.dart
@@ -60,10 +60,14 @@ class ColorOption extends StatelessWidget {
                         showColorName: true,
                         showColorCode: true,
                         copyPasteBehavior: const ColorPickerCopyPasteBehavior(
-                          copyButton: true,
-                          pasteButton: true,
-                          ctrlC: true,
-                          ctrlV: true,
+                          copyFormat: ColorPickerCopyFormat.hexRRGGBB,
+                          parseShortHexCode: true,
+                          editUsesParsedPaste: true,
+                          copyButton: false,
+                          pasteButton: false,
+                          ctrlC: false,
+                          ctrlV: false,
+                          autoFocus: false,
                         ),
                         colorNameTextStyle:
                             TextStyle(color: colorScheme.onSurface),


### PR DESCRIPTION
This pull request makes changes to the `ColorOption` class in the `lib/widgets/options/color_option.dart` file to update the behavior and configuration of the color picker. The most important changes include modifications to the `ColorPickerCopyPasteBehavior` settings.

Changes to `ColorPickerCopyPasteBehavior`:

* Updated the `copyFormat` to use `ColorPickerCopyFormat.hexRRGGBB`.
* Enabled `parseShortHexCode` and `editUsesParsedPaste` options.
* Disabled `copyButton`, `pasteButton`, `ctrlC`, `ctrlV`, and added `autoFocus` set to false.