### PR TITLE
feat: add support for reactive shifted keys

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -140,6 +140,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   final PreferencesService _prefsService = PreferencesService();
   final KanataService _kanataService = KanataService();
   final Map<String, bool> _keyPressStates = {};
+  Map<String, String>? _customShiftMappings;
 
   // Overlay
   bool _showStatusOverlay = false;
@@ -163,6 +164,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     _setupMethodHandler();
     _initStartup();
     _setupKanataLayerChangeHandler();
+    _loadCustomShiftMappings();
     if (_advancedSettingsEnabled) {
       if (_useUserLayout) {
         _loadUserLayout();
@@ -375,6 +377,14 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     };
 
     await _prefsService.saveAllPreferences(prefs);
+  }
+
+  Future<void> _loadCustomShiftMappings() async {
+    final configService = ConfigService();
+    final mappings = await configService.getCustomShiftMappings();
+    setState(() {
+      _customShiftMappings = mappings;
+    });
   }
 
   void _setupKanataLayerChangeHandler() {
@@ -1189,6 +1199,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
                       altLayout: _altLayout,
                       use6ColLayout: _use6ColLayout,
                       keyPressStates: _keyPressStates,
+                      customShiftMappings: _customShiftMappings,
                     ),
                   ),
                 ),

--- a/lib/models/mappings.dart
+++ b/lib/models/mappings.dart
@@ -141,4 +141,32 @@ class Mappings {
   static String getKeyForSymbol(String symbol) {
     return keyMappings[symbol] ?? symbol;
   }
+
+  static String? getShiftedSymbol(String symbol) {
+    const Map<String, String> shiftedSymbols = {
+      '`': '~',
+      '1': '!',
+      '2': '@',
+      '3': '#',
+      '4': '\$',
+      '5': '%',
+      '6': '^',
+      '7': '&',
+      '8': '*',
+      '9': '(',
+      '0': ')',
+      '-': '_',
+      '=': '+',
+      '[': '{',
+      ']': '}',
+      '\\': '|',
+      ';': ':',
+      '\'': '"',
+      ',': '<',
+      '.': '>',
+      '/': '?'
+    };
+
+    return shiftedSymbols[symbol] ?? symbol;
+  }
 }

--- a/lib/models/user_config.dart
+++ b/lib/models/user_config.dart
@@ -1,12 +1,13 @@
 import 'keyboard_layouts.dart';
 
 class UserConfig {
-  String kanataHost;
-  int kanataPort;
-  List<KeyboardLayout> userLayouts;
   String defaultUserLayout;
   String altLayout;
   String customFont;
+  List<KeyboardLayout> userLayouts;
+  Map<String, String>? customShiftMappings;
+  String kanataHost;
+  int kanataPort;
 
   UserConfig({
     this.defaultUserLayout = 'Symbol',
@@ -54,6 +55,7 @@ class UserConfig {
         ],
       ),
     ],
+    this.customShiftMappings,
     this.kanataHost = '127.0.0.1',
     this.kanataPort = 4039,
   });
@@ -71,13 +73,19 @@ class UserConfig {
       }
     }
 
+    Map<String, String>? customShiftMappings;
+    if (json['customShiftMappings'] != null) {
+      customShiftMappings = Map<String, String>.from(json['customShiftMappings']);
+    }
+
     return UserConfig(
-      kanataHost: json['kanataHost'] ?? '127.0.0.1',
-      kanataPort: json['kanataPort'] ?? 4039,
-      userLayouts: layers,
       defaultUserLayout: json['defaultUserLayout'] ?? 'Symbol',
       altLayout: json['altLayout'] ?? 'Arabic',
       customFont: json['customFont'] ?? 'Segoe UI',
+      userLayouts: layers,
+      customShiftMappings: customShiftMappings,
+      kanataHost: json['kanataHost'] ?? '127.0.0.1',
+      kanataPort: json['kanataPort'] ?? 4039,
     );
   }
 
@@ -90,12 +98,13 @@ class UserConfig {
         .toList();
 
     return {
-      'kanataHost': kanataHost,
-      'kanataPort': kanataPort,
-      'userLayouts': layersJson,
       'defaultUserLayout': defaultUserLayout,
       'altLayout': altLayout,
       'customFont': customFont,
+      'userLayouts': layersJson,
+      'customShiftMappings': customShiftMappings,
+      'kanataHost': kanataHost,
+      'kanataPort': kanataPort,
     };
   }
 }

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -46,6 +46,7 @@ class KeyboardScreen extends StatelessWidget {
   final KeyboardLayout? altLayout;
   final bool use6ColLayout;
   final Map<String, bool> keyPressStates;
+  final Map<String, String>? customShiftMappings;
 
   const KeyboardScreen({
     super.key,
@@ -92,6 +93,7 @@ class KeyboardScreen extends StatelessWidget {
     required this.altLayout,
     required this.use6ColLayout,
     required this.keyPressStates,
+    this.customShiftMappings,
   });
 
   @override
@@ -184,7 +186,12 @@ class KeyboardScreen extends StatelessWidget {
     bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
         (keyPressStates["RShift"] ?? false);
     if (isShiftPressed) {
-      key = Mappings.getShiftedSymbol(key) ?? key;
+      if (customShiftMappings != null &&
+          customShiftMappings!.containsKey(key)) {
+        key = customShiftMappings![key]!;
+      } else {
+        key = Mappings.getShiftedSymbol(key) ?? key;
+      }
     }
     String keyStateKey = Mappings.getKeyForSymbol(key);
     bool isPressed = keyPressStates[keyStateKey] ?? false;
@@ -411,9 +418,14 @@ class KeyboardScreen extends StatelessWidget {
     }
     String altKey = altRow[keyIndex];
     bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
-      (keyPressStates["RShift"] ?? false);
+        (keyPressStates["RShift"] ?? false);
     if (isShiftPressed) {
-      altKey = Mappings.getShiftedSymbol(altKey) ?? altKey;
+      if (customShiftMappings != null &&
+          customShiftMappings!.containsKey(altKey)) {
+        altKey = customShiftMappings![altKey]!;
+      } else {
+        altKey = Mappings.getShiftedSymbol(altKey) ?? altKey;
+      }
     }
     return altKey;
   }

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -181,6 +181,11 @@ class KeyboardScreen extends StatelessWidget {
 
   Widget buildKeys(int rowIndex, String key, int keyIndex,
       {bool isLastKeyFirstRow = false}) {
+    bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
+        (keyPressStates["RShift"] ?? false);
+    if (isShiftPressed) {
+      key = Mappings.getShiftedSymbol(key) ?? key;
+    }
     String keyStateKey = Mappings.getKeyForSymbol(key);
     bool isPressed = keyPressStates[keyStateKey] ?? false;
 
@@ -404,7 +409,13 @@ class KeyboardScreen extends StatelessWidget {
     if (keyIndex >= altRow.length) {
       return "";
     }
-    return altRow[keyIndex];
+    String altKey = altRow[keyIndex];
+    bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
+      (keyPressStates["RShift"] ?? false);
+    if (isShiftPressed) {
+      altKey = Mappings.getShiftedSymbol(altKey) ?? altKey;
+    }
+    return altKey;
   }
 
   Color getFingerColor(int rowIndex, int keyIndex) {

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -94,4 +94,9 @@ class ConfigService {
       return null;
     }
   }
+
+  Future<Map<String, String>?> getCustomShiftMappings() async {
+    final config = await loadConfig();
+    return config.customShiftMappings;
+  }
 }


### PR DESCRIPTION
This pull request introduces a feature to support custom shift key mappings in the application. The main changes include adding a method to load custom shift mappings, updating the `UserConfig` model, and modifying the `KeyboardScreen` to use these mappings.

### Custom Shift Mappings Feature:

* `lib/app.dart`: 
  * Added a new field `_customShiftMappings` and a method `_loadCustomShiftMappings` to load custom shift mappings from the configuration service. This method is called during initialization. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR143) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR167) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR382-R389)
  * Updated the `KeyboardScreen` widget instantiation to pass the custom shift mappings.

* `lib/models/mappings.dart`: 
  * Added a static method `getShiftedSymbol` to return the shifted symbol for a given key.

* `lib/models/user_config.dart`: 
  * Added a new field `customShiftMappings` to the `UserConfig` class and updated the methods for JSON serialization and deserialization to include this field. [[1]](diffhunk://#diff-b861c9c4d28a6a1a6635164a4eeaeb4e193fb6047a2d22b729baedef26e58c21L4-R10) [[2]](diffhunk://#diff-b861c9c4d28a6a1a6635164a4eeaeb4e193fb6047a2d22b729baedef26e58c21R58) [[3]](diffhunk://#diff-b861c9c4d28a6a1a6635164a4eeaeb4e193fb6047a2d22b729baedef26e58c21R76-R88) [[4]](diffhunk://#diff-b861c9c4d28a6a1a6635164a4eeaeb4e193fb6047a2d22b729baedef26e58c21L93-R107)

* `lib/screens/keyboard_screen.dart`: 
  * Updated the `KeyboardScreen` class to accept `customShiftMappings` and modified the key rendering logic to use these mappings when the shift key is pressed. [[1]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642R49) [[2]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642R96) [[3]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642R186-R195) [[4]](diffhunk://#diff-ac4b6e417eba6a940fb08768e2fb06018390b198a7c04dc06f89d024feaf4642L407-R430)

* `lib/services/config_service.dart`: 
  * Added a method `getCustomShiftMappings` to load the custom shift mappings from the configuration.