### PR TITLE
feat: disable/enable specific hotkeys

### DIFF
--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -513,7 +513,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       case 'Animations':
         return const Icon(LucideIcons.sparkles);
       case 'Hotkeys':
-        return const Icon(LucideIcons.layers);
+        return const Icon(LucideIcons.zap);
       case 'Learn':
         return const Icon(LucideIcons.graduationCap);
       case 'Advanced':

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -104,6 +104,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     key: PhysicalKeyboardKey.keyR,
     modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
   );
+  bool _enableVisibilityHotKey = true;
+  bool _enableAutoHideHotKey = true;
+  bool _enableToggleMoveHotKey = true;
+  bool _enablePreferencesHotKey = true;
 
   // Learn settings
   bool _learningModeEnabled = false;
@@ -239,6 +243,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _autoHideHotKey = prefs['autoHideHotKey'];
       _toggleMoveHotKey = prefs['toggleMoveHotKey'];
       _preferencesHotKey = prefs['preferencesHotKey'];
+      _enableVisibilityHotKey = prefs['enableVisibilityHotKey'] ?? true;
+      _enableAutoHideHotKey = prefs['enableAutoHideHotKey'] ?? true;
+      _enableToggleMoveHotKey = prefs['enableToggleMoveHotKey'] ?? true;
+      _enablePreferencesHotKey = prefs['enablePreferencesHotKey'] ?? true;
 
       // Learn settings
       _learningModeEnabled = prefs['learningModeEnabled'] ?? false;
@@ -317,6 +325,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       'autoHideHotKey': _autoHideHotKey,
       'toggleMoveHotKey': _toggleMoveHotKey,
       'preferencesHotKey': _preferencesHotKey,
+      'enableVisibilityHotKey': _enableVisibilityHotKey,
+      'enableAutoHideHotKey': _enableAutoHideHotKey,
+      'enableToggleMoveHotKey': _enableToggleMoveHotKey,
+      'enablePreferencesHotKey': _enablePreferencesHotKey,
 
       // Learn settings
       'learningModeEnabled': _learningModeEnabled,
@@ -717,6 +729,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           autoHideHotKey: _autoHideHotKey,
           toggleMoveHotKey: _toggleMoveHotKey,
           preferencesHotKey: _preferencesHotKey,
+          enableVisibilityHotKey: _enableVisibilityHotKey,
+          enableAutoHideHotKey: _enableAutoHideHotKey,
+          enableToggleMoveHotKey: _enableToggleMoveHotKey,
+          enablePreferencesHotKey: _enablePreferencesHotKey,
           updateHotKeysEnabled: (value) {
             setState(() => _hotKeysEnabled = value);
             _updateMainWindow('updateHotKeysEnabled', value);
@@ -736,6 +752,22 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updatePreferencesHotKey: (value) {
             setState(() => _preferencesHotKey = value);
             _updateMainWindow('updatePreferencesHotKey', value);
+          },
+          updateEnableVisibilityHotKey: (value) {
+            setState(() => _enableVisibilityHotKey = value);
+            _updateMainWindow('updateEnableVisibilityHotKey', value);
+          },
+          updateEnableAutoHideHotKey: (value) {
+            setState(() => _enableAutoHideHotKey = value);
+            _updateMainWindow('updateEnableAutoHideHotKey', value);
+          },
+          updateEnableToggleMoveHotKey: (value) {
+            setState(() => _enableToggleMoveHotKey = value);
+            _updateMainWindow('updateEnableToggleMoveHotKey', value);
+          },
+          updateEnablePreferencesHotKey: (value) {
+            setState(() => _enablePreferencesHotKey = value);
+            _updateMainWindow('updateEnablePreferencesHotKey', value);
           },
         );
       case 'Learn':

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -136,6 +136,14 @@ class PreferencesService {
       );
     }
   }
+  Future<bool> getEnableVisibilityHotKey() async =>
+      await _prefs.getBool('enableVisibilityHotKey') ?? true;
+  Future<bool> getEnableAutoHideHotKey() async =>
+      await _prefs.getBool('enableAutoHideHotKey') ?? true;
+  Future<bool> getEnableToggleMoveHotKey() async =>
+      await _prefs.getBool('enableToggleMoveHotKey') ?? true;
+  Future<bool> getEnablePreferencesHotKey() async =>
+      await _prefs.getBool('enablePreferencesHotKey') ?? true;
 
   // Learn settings
   Future<bool> getLearningModeEnabled() async =>
@@ -266,6 +274,14 @@ class PreferencesService {
       await _prefs.setString('toggleMoveHotKey', jsonEncode(value.toJson()));
   Future<void> setPreferencesHotKey(HotKey value) async =>
       await _prefs.setString('preferencesHotKey', jsonEncode(value.toJson()));
+  Future<void> setEnableVisibilityHotKey(bool value) async =>
+      await _prefs.setBool('enableVisibilityHotKey', value);
+  Future<void> setEnableAutoHideHotKey(bool value) async =>
+      await _prefs.setBool('enableAutoHideHotKey', value);
+  Future<void> setEnableToggleMoveHotKey(bool value) async =>
+      await _prefs.setBool('enableToggleMoveHotKey', value);
+  Future<void> setEnablePreferencesHotKey(bool value) async =>
+      await _prefs.setBool('enablePreferencesHotKey', value);
 
   // Learn settings
   Future<void> setLearningModeEnabled(bool value) async =>
@@ -358,6 +374,10 @@ class PreferencesService {
       'autoHideHotKey': await getAutoHideHotKey(),
       'toggleMoveHotKey': await getToggleMoveHotKey(),
       'preferencesHotKey': await getPreferencesHotKey(),
+      'enableVisibilityHotKey': await getEnableVisibilityHotKey(),
+      'enableAutoHideHotKey': await getEnableAutoHideHotKey(),
+      'enableToggleMoveHotKey': await getEnableToggleMoveHotKey(),
+      'enablePreferencesHotKey': await getEnablePreferencesHotKey(),
 
       // Learn settings
       'learningModeEnabled': await getLearningModeEnabled(),
@@ -435,6 +455,10 @@ class PreferencesService {
     await setAutoHideHotKey(prefs['autoHideHotKey']);
     await setToggleMoveHotKey(prefs['toggleMoveHotKey']);
     await setPreferencesHotKey(prefs['preferencesHotKey']);
+    await setEnableVisibilityHotKey(prefs['enableVisibilityHotKey'] ?? true);
+    await setEnableAutoHideHotKey(prefs['enableAutoHideHotKey'] ?? true);
+    await setEnableToggleMoveHotKey(prefs['enableToggleMoveHotKey'] ?? true);
+    await setEnablePreferencesHotKey(prefs['enablePreferencesHotKey'] ?? true);
 
     // Learn settings
     await setLearningModeEnabled(prefs['learningModeEnabled'] ?? false);

--- a/lib/widgets/options/hotkey_option.dart
+++ b/lib/widgets/options/hotkey_option.dart
@@ -3,16 +3,22 @@ import 'base_option.dart';
 
 class HotKeyOption extends StatelessWidget {
   final String label;
-  final String? subtitle;
+  final String subtitle;
   final String formattedHotKey;
-  final Function() onChangePressed;
+  final bool enabled;
+  final bool isEnabled;
+  final Function(bool) onToggleChanged;
+  final VoidCallback onChangePressed;
 
   const HotKeyOption({
     super.key,
     required this.label,
+    required this.subtitle,
     required this.formattedHotKey,
+    required this.enabled,
+    required this.onToggleChanged,
     required this.onChangePressed,
-    this.subtitle,
+    required this.isEnabled,
   });
 
   @override
@@ -36,19 +42,18 @@ class HotKeyOption extends StatelessWidget {
                     fontSize: 16,
                   ),
                 ),
-                if (subtitle != null)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4.0),
-                    child: Text(
-                      subtitle!,
-                      style: TextStyle(
-                        color: colorScheme.onSurface.withAlpha(153),
-                        fontSize: 14.0,
-                      ),
-                      softWrap: true,
-                      overflow: TextOverflow.visible,
+                Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Text(
+                    subtitle,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withAlpha(153),
+                      fontSize: 14.0,
                     ),
+                    softWrap: true,
+                    overflow: TextOverflow.visible,
                   ),
+                ),
               ],
             ),
           ),
@@ -56,20 +61,34 @@ class HotKeyOption extends StatelessWidget {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHigh,
-                  borderRadius: BorderRadius.circular(8),
+              Switch(
+                thumbIcon: const WidgetStateProperty<Icon>.fromMap(
+                  <WidgetStatesConstraint, Icon>{
+                    WidgetState.selected: Icon(Icons.check),
+                    WidgetState.any: Icon(Icons.close),
+                  },
                 ),
-                child: Text(
-                  formattedHotKey,
-                  style: TextStyle(
-                    fontWeight: FontWeight.w500,
-                    fontFamily: 'Geist Mono',
-                    color: colorScheme.onSurfaceVariant,
-                    fontSize: 14,
+                value: enabled,
+                onChanged: isEnabled ? onToggleChanged : null,
+              ),
+              const SizedBox(width: 12),
+              Opacity(
+                opacity: enabled ? 1.0 : 0.35,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHigh,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    formattedHotKey,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w500,
+                      fontFamily: 'Geist Mono',
+                      color: colorScheme.onSurfaceVariant,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
               ),
@@ -85,7 +104,7 @@ class HotKeyOption extends StatelessWidget {
                     side: BorderSide(color: colorScheme.primary),
                   ),
                 ),
-                onPressed: onChangePressed,
+                onPressed: enabled ? onChangePressed : null,
                 child: Text(
                   'Change',
                   style: TextStyle(

--- a/lib/widgets/tabs/general_tab.dart
+++ b/lib/widgets/tabs/general_tab.dart
@@ -110,6 +110,14 @@ class _GeneralTabState extends State<GeneralTab> {
           options: availableLayouts.map((layout) => (layout.name)).toList(),
           onChanged: (value) => widget.updateKeyboardLayoutName(value!),
         ),
+        Text(
+          'Tip: Press ESC key to close the preferences window',
+          style: TextStyle(
+            fontSize: 16,
+            fontStyle: FontStyle.italic,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        ),
       ],
     );
   }

--- a/lib/widgets/tabs/hotkeys_tab.dart
+++ b/lib/widgets/tabs/hotkeys_tab.dart
@@ -9,11 +9,19 @@ class HotKeysTab extends StatefulWidget {
   final HotKey autoHideHotKey;
   final HotKey toggleMoveHotKey;
   final HotKey preferencesHotKey;
+  final bool enableVisibilityHotKey;
+  final bool enableAutoHideHotKey;
+  final bool enableToggleMoveHotKey;
+  final bool enablePreferencesHotKey;
   final Function(bool) updateHotKeysEnabled;
   final Function(HotKey) updateVisibilityHotKey;
   final Function(HotKey) updateAutoHideHotKey;
   final Function(HotKey) updateToggleMoveHotKey;
   final Function(HotKey) updatePreferencesHotKey;
+  final Function(bool) updateEnableVisibilityHotKey;
+  final Function(bool) updateEnableAutoHideHotKey;
+  final Function(bool) updateEnableToggleMoveHotKey;
+  final Function(bool) updateEnablePreferencesHotKey;
 
   const HotKeysTab({
     super.key,
@@ -27,6 +35,14 @@ class HotKeysTab extends StatefulWidget {
     required this.updateAutoHideHotKey,
     required this.updateToggleMoveHotKey,
     required this.updatePreferencesHotKey,
+    required this.enableVisibilityHotKey,
+    required this.enableAutoHideHotKey,
+    required this.enableToggleMoveHotKey,
+    required this.enablePreferencesHotKey,
+    required this.updateEnableVisibilityHotKey,
+    required this.updateEnableAutoHideHotKey,
+    required this.updateEnableToggleMoveHotKey,
+    required this.updateEnablePreferencesHotKey,
   });
 
   @override
@@ -48,41 +64,53 @@ class _HotKeysTabState extends State<HotKeysTab> {
           subtitle:
               'Force show or hide the overlay with a keyboard shortcut even if it\'s set to auto-hide',
           formattedHotKey: _formatHotKey(widget.visibilityHotKey),
+          enabled: widget.enableVisibilityHotKey,
+          onToggleChanged: widget.updateEnableVisibilityHotKey,
           onChangePressed: () => _showRecordHotKeyDialog(
             context,
             widget.updateVisibilityHotKey,
             widget.visibilityHotKey,
           ),
+          isEnabled: widget.hotKeysEnabled,
         ),
         HotKeyOption(
           label: 'Toggle Auto Hide',
           subtitle: 'Enable or disable auto-hide feature',
           formattedHotKey: _formatHotKey(widget.autoHideHotKey),
+          enabled: widget.enableAutoHideHotKey,
+          onToggleChanged: widget.updateEnableAutoHideHotKey,
           onChangePressed: () => _showRecordHotKeyDialog(
             context,
             widget.updateAutoHideHotKey,
             widget.autoHideHotKey,
           ),
+          isEnabled: widget.hotKeysEnabled,
         ),
         HotKeyOption(
           label: 'Toggle Move',
           subtitle: 'Enable or disable keyboard dragging',
           formattedHotKey: _formatHotKey(widget.toggleMoveHotKey),
+          enabled: widget.enableToggleMoveHotKey,
+          onToggleChanged: widget.updateEnableToggleMoveHotKey,
           onChangePressed: () => _showRecordHotKeyDialog(
             context,
             widget.updateToggleMoveHotKey,
             widget.toggleMoveHotKey,
           ),
+          isEnabled: widget.hotKeysEnabled,
         ),
         HotKeyOption(
           label: 'Open Preferences',
           subtitle: 'Show/focus the preferences window',
           formattedHotKey: _formatHotKey(widget.preferencesHotKey),
+          enabled: widget.enablePreferencesHotKey,
+          onToggleChanged: widget.updateEnablePreferencesHotKey,
           onChangePressed: () => _showRecordHotKeyDialog(
             context,
             widget.updatePreferencesHotKey,
             widget.preferencesHotKey,
           ),
+          isEnabled: widget.hotKeysEnabled,
         ),
       ],
     );


### PR DESCRIPTION
This pull request introduces new functionality to enable or disable specific hotkeys and updates the preferences and UI components accordingly. The changes span multiple files, including `lib/app.dart`, `lib/screens/preferences_screen.dart`, `lib/services/preferences_service.dart`, and `lib/widgets/options/hotkey_option.dart`.

### Hotkey Enabling/Disabling Functionality:

* [`lib/app.dart`](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR115-R118): Added boolean flags for enabling/disabling hotkeys, updated methods to check these flags before registering hotkeys, and added cases to handle updates to these flags. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR115-R118) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR282-R285) [[3]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR365-R368) [[4]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR679) [[5]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR690-R692) [[6]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR705-R707) [[7]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR726-R741) [[8]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR1004-R1019)

* [`lib/screens/preferences_screen.dart`](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R107-R110): Added new boolean flags for enabling/disabling hotkeys, updated preferences loading and saving methods to include these flags, and updated the UI to handle these new preferences. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R107-R110) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R246-R249) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R328-R331) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R732-R735) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R756-R771)

### Preferences Service Updates:

* [`lib/services/preferences_service.dart`](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R139-R146): Added methods to get and set the new boolean flags for enabling/disabling hotkeys, updated the preferences loading and saving methods to handle these new flags. [[1]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R139-R146) [[2]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R277-R284) [[3]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R377-R380) [[4]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R458-R461)

### UI Enhancements:

* [`lib/widgets/options/hotkey_option.dart`](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8L6-R21): Modified the `HotKeyOption` class to include a switch for enabling/disabling hotkeys, updated the UI to reflect the enabled state, and adjusted the `onChangePressed` button behavior based on the enabled state. [[1]](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8L6-R21) [[2]](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8L39-R48) [[3]](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8L59-R77) [[4]](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8R94) [[5]](diffhunk://#diff-471258cd3a7d233c9d61084f5e251bb54528579cf56e10a639b46c1db10715b8L88-R107)

* [`lib/widgets/tabs/general_tab.dart`](diffhunk://#diff-461d4f8a6f34e89ad4d637721997466d510df60abadefdedabc6f7988d3e2241R113-R120): Added a tip to inform users about closing the preferences window using the ESC key.

* [`lib/widgets/tabs/hotkeys_tab.dart`](diffhunk://#diff-f311f9faeb1de6e4390949b707c82495304473fc84b24044bd088133ffc0839bR12-R24): Updated the `HotKeysTab` class to include the new boolean flags and their corresponding update functions. [[1]](diffhunk://#diff-f311f9faeb1de6e4390949b707c82495304473fc84b24044bd088133ffc0839bR12-R24) [[2]](diffhunk://#diff-f311f9faeb1de6e4390949b707c82495304473fc84b24044bd088133ffc0839bR38-R45)