### PR TITLE
feat: add hotkeys for increasing/decreasing opacity

### DIFF
--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -104,10 +104,20 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     key: PhysicalKeyboardKey.keyR,
     modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
   );
+  HotKey _increaseOpacityHotKey = HotKey(
+    key: PhysicalKeyboardKey.arrowUp,
+    modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
+  );
+  HotKey _decreaseOpacityHotKey = HotKey(
+    key: PhysicalKeyboardKey.arrowDown,
+    modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
+  );
   bool _enableVisibilityHotKey = true;
   bool _enableAutoHideHotKey = true;
   bool _enableToggleMoveHotKey = true;
   bool _enablePreferencesHotKey = true;
+  bool _enableIncreaseOpacityHotKey = true;
+  bool _enableDecreaseOpacityHotKey = true;
 
   // Learn settings
   bool _learningModeEnabled = false;
@@ -172,6 +182,11 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     DesktopMultiWindow.setMethodHandler((call, fromWindowId) async {
       if (call.method == 'getWindowType') {
         return jsonEncode({'type': 'preferences'});
+      }
+
+      if (call.method == 'updateOpacityFromMainWindow' && mounted) {
+        setState(() => _opacity = call.arguments as double);
+        await _prefsService.setOpacity(_opacity);
       }
 
       if (call.method == 'updateAutoHideFromMainWindow' && mounted) {
@@ -243,10 +258,16 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _autoHideHotKey = prefs['autoHideHotKey'];
       _toggleMoveHotKey = prefs['toggleMoveHotKey'];
       _preferencesHotKey = prefs['preferencesHotKey'];
+      _increaseOpacityHotKey = prefs['increaseOpacityHotKey'];
+      _decreaseOpacityHotKey = prefs['decreaseOpacityHotKey'];
       _enableVisibilityHotKey = prefs['enableVisibilityHotKey'] ?? true;
       _enableAutoHideHotKey = prefs['enableAutoHideHotKey'] ?? true;
       _enableToggleMoveHotKey = prefs['enableToggleMoveHotKey'] ?? true;
       _enablePreferencesHotKey = prefs['enablePreferencesHotKey'] ?? true;
+      _enableIncreaseOpacityHotKey =
+          prefs['enableIncreaseOpacityHotKey'] ?? true;
+      _enableDecreaseOpacityHotKey =
+          prefs['enableDecreaseOpacityHotKey'] ?? true;
 
       // Learn settings
       _learningModeEnabled = prefs['learningModeEnabled'] ?? false;
@@ -325,10 +346,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       'autoHideHotKey': _autoHideHotKey,
       'toggleMoveHotKey': _toggleMoveHotKey,
       'preferencesHotKey': _preferencesHotKey,
+      'increaseOpacityHotKey': _increaseOpacityHotKey,
+      'decreaseOpacityHotKey': _decreaseOpacityHotKey,
       'enableVisibilityHotKey': _enableVisibilityHotKey,
       'enableAutoHideHotKey': _enableAutoHideHotKey,
       'enableToggleMoveHotKey': _enableToggleMoveHotKey,
       'enablePreferencesHotKey': _enablePreferencesHotKey,
+      'enableIncreaseOpacityHotKey': _enableIncreaseOpacityHotKey,
+      'enableDecreaseOpacityHotKey': _enableDecreaseOpacityHotKey,
 
       // Learn settings
       'learningModeEnabled': _learningModeEnabled,
@@ -729,10 +754,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           autoHideHotKey: _autoHideHotKey,
           toggleMoveHotKey: _toggleMoveHotKey,
           preferencesHotKey: _preferencesHotKey,
+          increaseOpacityHotKey: _increaseOpacityHotKey,
+          decreaseOpacityHotKey: _decreaseOpacityHotKey,
           enableVisibilityHotKey: _enableVisibilityHotKey,
           enableAutoHideHotKey: _enableAutoHideHotKey,
           enableToggleMoveHotKey: _enableToggleMoveHotKey,
           enablePreferencesHotKey: _enablePreferencesHotKey,
+          enableIncreaseOpacityHotKey: _enableIncreaseOpacityHotKey,
+          enableDecreaseOpacityHotKey: _enableDecreaseOpacityHotKey,
           updateHotKeysEnabled: (value) {
             setState(() => _hotKeysEnabled = value);
             _updateMainWindow('updateHotKeysEnabled', value);
@@ -753,6 +782,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
             setState(() => _preferencesHotKey = value);
             _updateMainWindow('updatePreferencesHotKey', value);
           },
+          updateIncreaseOpacityHotKey: (value) {
+            setState(() => _increaseOpacityHotKey = value);
+            _updateMainWindow('updateIncreaseOpacityHotKey', value);
+          },
+          updateDecreaseOpacityHotKey: (value) {
+            setState(() => _decreaseOpacityHotKey = value);
+            _updateMainWindow('updateDecreaseOpacityHotKey', value);
+          },
           updateEnableVisibilityHotKey: (value) {
             setState(() => _enableVisibilityHotKey = value);
             _updateMainWindow('updateEnableVisibilityHotKey', value);
@@ -768,6 +805,14 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updateEnablePreferencesHotKey: (value) {
             setState(() => _enablePreferencesHotKey = value);
             _updateMainWindow('updateEnablePreferencesHotKey', value);
+          },
+          updateEnableIncreaseOpacityHotKey: (value) {
+            setState(() => _enableIncreaseOpacityHotKey = value);
+            _updateMainWindow('updateEnableIncreaseOpacityHotKey', value);
+          },
+          updateEnableDecreaseOpacityHotKey: (value) {
+            setState(() => _enableDecreaseOpacityHotKey = value);
+            _updateMainWindow('updateEnableDecreaseOpacityHotKey', value);
           },
         );
       case 'Learn':

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -136,6 +136,31 @@ class PreferencesService {
       );
     }
   }
+
+  Future<HotKey?> getIncreaseOpacityHotKey() async {
+    final json = await _prefs.getString('increaseOpacityHotKey');
+    try {
+      return HotKey.fromJson(jsonDecode(json!));
+    } catch (e) {
+      return HotKey(
+        key: PhysicalKeyboardKey.arrowUp,
+        modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
+      );
+    }
+  }
+
+  Future<HotKey?> getDecreaseOpacityHotKey() async {
+    final json = await _prefs.getString('decreaseOpacityHotKey');
+    try {
+      return HotKey.fromJson(jsonDecode(json!));
+    } catch (e) {
+      return HotKey(
+        key: PhysicalKeyboardKey.arrowDown,
+        modifiers: [HotKeyModifier.alt, HotKeyModifier.control],
+      );
+    }
+  }
+
   Future<bool> getEnableVisibilityHotKey() async =>
       await _prefs.getBool('enableVisibilityHotKey') ?? true;
   Future<bool> getEnableAutoHideHotKey() async =>
@@ -144,6 +169,10 @@ class PreferencesService {
       await _prefs.getBool('enableToggleMoveHotKey') ?? true;
   Future<bool> getEnablePreferencesHotKey() async =>
       await _prefs.getBool('enablePreferencesHotKey') ?? true;
+  Future<bool> getEnableIncreaseOpacityHotKey() async =>
+      await _prefs.getBool('enableIncreaseOpacityHotKey') ?? true;
+  Future<bool> getEnableDecreaseOpacityHotKey() async =>
+      await _prefs.getBool('enableDecreaseOpacityHotKey') ?? true;
 
   // Learn settings
   Future<bool> getLearningModeEnabled() async =>
@@ -274,6 +303,10 @@ class PreferencesService {
       await _prefs.setString('toggleMoveHotKey', jsonEncode(value.toJson()));
   Future<void> setPreferencesHotKey(HotKey value) async =>
       await _prefs.setString('preferencesHotKey', jsonEncode(value.toJson()));
+  Future<void> setIncreaseOpacityHotKey(HotKey value) async =>
+      await _prefs.setString('increaseOpacityHotKey', jsonEncode(value.toJson()));
+  Future<void> setDecreaseOpacityHotKey(HotKey value) async =>
+      await _prefs.setString('decreaseOpacityHotKey', jsonEncode(value.toJson()));
   Future<void> setEnableVisibilityHotKey(bool value) async =>
       await _prefs.setBool('enableVisibilityHotKey', value);
   Future<void> setEnableAutoHideHotKey(bool value) async =>
@@ -282,6 +315,10 @@ class PreferencesService {
       await _prefs.setBool('enableToggleMoveHotKey', value);
   Future<void> setEnablePreferencesHotKey(bool value) async =>
       await _prefs.setBool('enablePreferencesHotKey', value);
+  Future<void> setEnableIncreaseOpacityHotKey(bool value) async =>
+      await _prefs.setBool('enableIncreaseOpacityHotKey', value);
+  Future<void> setEnableDecreaseOpacityHotKey(bool value) async =>
+      await _prefs.setBool('enableDecreaseOpacityHotKey', value);
 
   // Learn settings
   Future<void> setLearningModeEnabled(bool value) async =>
@@ -374,10 +411,14 @@ class PreferencesService {
       'autoHideHotKey': await getAutoHideHotKey(),
       'toggleMoveHotKey': await getToggleMoveHotKey(),
       'preferencesHotKey': await getPreferencesHotKey(),
+      'increaseOpacityHotKey': await getIncreaseOpacityHotKey(),
+      'decreaseOpacityHotKey': await getDecreaseOpacityHotKey(),
       'enableVisibilityHotKey': await getEnableVisibilityHotKey(),
       'enableAutoHideHotKey': await getEnableAutoHideHotKey(),
       'enableToggleMoveHotKey': await getEnableToggleMoveHotKey(),
       'enablePreferencesHotKey': await getEnablePreferencesHotKey(),
+      'enableIncreaseOpacityHotKey': await getEnableIncreaseOpacityHotKey(),
+      'enableDecreaseOpacityHotKey': await getEnableDecreaseOpacityHotKey(),
 
       // Learn settings
       'learningModeEnabled': await getLearningModeEnabled(),
@@ -455,10 +496,14 @@ class PreferencesService {
     await setAutoHideHotKey(prefs['autoHideHotKey']);
     await setToggleMoveHotKey(prefs['toggleMoveHotKey']);
     await setPreferencesHotKey(prefs['preferencesHotKey']);
+    await setIncreaseOpacityHotKey(prefs['increaseOpacityHotKey']);
+    await setDecreaseOpacityHotKey(prefs['decreaseOpacityHotKey']);
     await setEnableVisibilityHotKey(prefs['enableVisibilityHotKey'] ?? true);
     await setEnableAutoHideHotKey(prefs['enableAutoHideHotKey'] ?? true);
     await setEnableToggleMoveHotKey(prefs['enableToggleMoveHotKey'] ?? true);
     await setEnablePreferencesHotKey(prefs['enablePreferencesHotKey'] ?? true);
+    await setEnableIncreaseOpacityHotKey(prefs['enableIncreaseOpacityHotKey'] ?? true);
+    await setEnableDecreaseOpacityHotKey(prefs['enableDecreaseOpacityHotKey'] ?? true);
 
     // Learn settings
     await setLearningModeEnabled(prefs['learningModeEnabled'] ?? false);

--- a/lib/widgets/tabs/hotkeys_tab.dart
+++ b/lib/widgets/tabs/hotkeys_tab.dart
@@ -9,19 +9,27 @@ class HotKeysTab extends StatefulWidget {
   final HotKey autoHideHotKey;
   final HotKey toggleMoveHotKey;
   final HotKey preferencesHotKey;
+  final HotKey increaseOpacityHotKey;
+  final HotKey decreaseOpacityHotKey;
   final bool enableVisibilityHotKey;
   final bool enableAutoHideHotKey;
   final bool enableToggleMoveHotKey;
   final bool enablePreferencesHotKey;
+  final bool enableIncreaseOpacityHotKey;
+  final bool enableDecreaseOpacityHotKey;
   final Function(bool) updateHotKeysEnabled;
   final Function(HotKey) updateVisibilityHotKey;
   final Function(HotKey) updateAutoHideHotKey;
   final Function(HotKey) updateToggleMoveHotKey;
   final Function(HotKey) updatePreferencesHotKey;
+  final Function(HotKey) updateIncreaseOpacityHotKey;
+  final Function(HotKey) updateDecreaseOpacityHotKey;
   final Function(bool) updateEnableVisibilityHotKey;
   final Function(bool) updateEnableAutoHideHotKey;
   final Function(bool) updateEnableToggleMoveHotKey;
   final Function(bool) updateEnablePreferencesHotKey;
+  final Function(bool) updateEnableIncreaseOpacityHotKey;
+  final Function(bool) updateEnableDecreaseOpacityHotKey;
 
   const HotKeysTab({
     super.key,
@@ -30,19 +38,27 @@ class HotKeysTab extends StatefulWidget {
     required this.autoHideHotKey,
     required this.toggleMoveHotKey,
     required this.preferencesHotKey,
+    required this.increaseOpacityHotKey,
+    required this.decreaseOpacityHotKey,
     required this.updateHotKeysEnabled,
     required this.updateVisibilityHotKey,
     required this.updateAutoHideHotKey,
     required this.updateToggleMoveHotKey,
     required this.updatePreferencesHotKey,
+    required this.updateIncreaseOpacityHotKey,
+    required this.updateDecreaseOpacityHotKey,
     required this.enableVisibilityHotKey,
     required this.enableAutoHideHotKey,
     required this.enableToggleMoveHotKey,
     required this.enablePreferencesHotKey,
+    required this.enableIncreaseOpacityHotKey,
+    required this.enableDecreaseOpacityHotKey,
     required this.updateEnableVisibilityHotKey,
     required this.updateEnableAutoHideHotKey,
     required this.updateEnableToggleMoveHotKey,
     required this.updateEnablePreferencesHotKey,
+    required this.updateEnableIncreaseOpacityHotKey,
+    required this.updateEnableDecreaseOpacityHotKey,
   });
 
   @override
@@ -109,6 +125,32 @@ class _HotKeysTabState extends State<HotKeysTab> {
             context,
             widget.updatePreferencesHotKey,
             widget.preferencesHotKey,
+          ),
+          isEnabled: widget.hotKeysEnabled,
+        ),
+        HotKeyOption(
+          label: 'Increase Opacity',
+          subtitle: 'Increase opacity by 5%',
+          formattedHotKey: _formatHotKey(widget.increaseOpacityHotKey),
+          enabled: widget.enableIncreaseOpacityHotKey,
+          onToggleChanged: widget.updateEnableIncreaseOpacityHotKey,
+          onChangePressed: () => _showRecordHotKeyDialog(
+            context,
+            widget.updateIncreaseOpacityHotKey,
+            widget.increaseOpacityHotKey,
+          ),
+          isEnabled: widget.hotKeysEnabled,
+        ),
+        HotKeyOption(
+          label: 'Decrease Opacity',
+          subtitle: 'Decrease opacity by 5%',
+          formattedHotKey: _formatHotKey(widget.decreaseOpacityHotKey),
+          enabled: widget.enableDecreaseOpacityHotKey,
+          onToggleChanged: widget.updateEnableDecreaseOpacityHotKey,
+          onChangePressed: () => _showRecordHotKeyDialog(
+            context,
+            widget.updateDecreaseOpacityHotKey,
+            widget.decreaseOpacityHotKey,
           ),
           isEnabled: widget.hotKeysEnabled,
         ),


### PR DESCRIPTION
This pull request introduces new functionality to manage opacity settings through hotkeys in the `lib/app.dart` and related files. The changes include adding new hotkeys for increasing and decreasing opacity, handling their preferences, and updating the UI accordingly.

### New Opacity Management Feature:

* Added constants for opacity control (`_opacityStep`, `_minOpacity`, `_maxOpacity`) in `lib/app.dart`.
* Introduced new hotkeys for increasing and decreasing opacity (`_increaseOpacityHotKey`, `_decreaseOpacityHotKey`) and their corresponding enable flags (`_enableIncreaseOpacityHotKey`, `_enableDecreaseOpacityHotKey`) in `lib/app.dart`.
* Implemented `_adjustOpacity` method to handle opacity changes and update the UI and preferences in `lib/app.dart`.
* Registered new hotkeys in the `_setupHotKeys` method to trigger opacity adjustments in `lib/app.dart`.

### Preferences Handling:

* Updated the preferences load and save methods to include the new opacity hotkeys and their enable flags in `lib/app.dart`. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR294-R301) [[2]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dR381-R388)
* Added methods to get and set the new opacity hotkeys and their enable flags in `lib/services/preferences_service.dart`. [[1]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R139-R163) [[2]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R172-R175) [[3]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R306-R309) [[4]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R318-R321)
* Updated the preferences synchronization methods to include the new opacity hotkeys in `lib/services/preferences_service.dart`. [[1]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R414-R421) [[2]](diffhunk://#diff-5c20e4f391fef1dc29009409c6e8c2b6a43ffa2b1ccba066d198e1f1ef6ea6d0R499-R506)

### UI Updates:

* Updated `lib/screens/preferences_screen.dart` to handle the new opacity hotkeys and synchronize them with the main window. [[1]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R107-R120) [[2]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R187-R191) [[3]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R261-R270) [[4]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R349-R356) [[5]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R757-R764) [[6]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R785-R792) [[7]](diffhunk://#diff-4a19cd31cd94bf2ea7104324e6aed7bcc866dfda0bba84bc0bef599be5ef36e5R809-R816)
* Modified `lib/widgets/tabs/hotkeys_tab.dart` to include new fields and functions for the opacity hotkeys.