### PR TITLE
feat: add option for enabling or disabling reactive shift

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1431,6 +1431,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
                       showAltLayout: _advancedSettingsEnabled && _showAltLayout,
                       altLayout: _altLayout,
                       use6ColLayout: _use6ColLayout,
+                      reactiveShiftEnabled: _reactiveShiftEnabled,
                       keyPressStates: _keyPressStates,
                       customShiftMappings: _customShiftMappings,
                     ),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -50,6 +50,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   // General settings
   bool _launchAtStartup = false;
   bool _autoHideEnabled = false;
+  bool _reactiveShiftEnabled = true;
   double _autoHideDuration = 2.0;
   double _opacity = 0.6;
   double _lastOpacity = 0.6;
@@ -230,6 +231,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       // General settings
       _launchAtStartup = prefs['launchAtStartup'];
       _autoHideEnabled = prefs['autoHideEnabled'];
+      _reactiveShiftEnabled = prefs['reactiveShiftEnabled'];
       _autoHideDuration = prefs['autoHideDuration'];
       _opacity = prefs['opacity'];
       _lastOpacity = prefs['opacity'];
@@ -322,6 +324,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       // General settings
       'launchAtStartup': _launchAtStartup,
       'autoHideEnabled': _autoHideEnabled,
+      'reactiveShiftEnabled': _reactiveShiftEnabled,
       'autoHideDuration': _autoHideDuration,
       'opacity': _opacity,
       'keyboardLayoutName': _initialKeyboardLayout!.name,
@@ -999,6 +1002,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         case 'updateAutoHideEnabled':
           final autoHideEnabled = call.arguments as bool;
           _toggleAutoHide(autoHideEnabled);
+        case 'updateReactiveShiftEnabled':
+          final reactiveShiftEnabled = call.arguments as bool;
+          setState(() => _reactiveShiftEnabled = reactiveShiftEnabled);
         case 'updateAutoHideDuration':
           final autoHideDuration = call.arguments as double;
           setState(() => _autoHideDuration = autoHideDuration);

--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -48,6 +48,7 @@ class KeyboardScreen extends StatelessWidget {
   final bool showAltLayout;
   final KeyboardLayout? altLayout;
   final bool use6ColLayout;
+  final bool reactiveShiftEnabled;
   final Map<String, bool> keyPressStates;
   final Map<String, String>? customShiftMappings;
 
@@ -98,6 +99,7 @@ class KeyboardScreen extends StatelessWidget {
     required this.showAltLayout,
     required this.altLayout,
     required this.use6ColLayout,
+    required this.reactiveShiftEnabled,
     required this.keyPressStates,
     this.customShiftMappings,
   });
@@ -191,7 +193,7 @@ class KeyboardScreen extends StatelessWidget {
       {bool isLastKeyFirstRow = false}) {
     bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
         (keyPressStates["RShift"] ?? false);
-    if (isShiftPressed) {
+    if (isShiftPressed && reactiveShiftEnabled) {
       if (customShiftMappings != null &&
           customShiftMappings!.containsKey(key)) {
         key = customShiftMappings![key]!;
@@ -444,7 +446,7 @@ class KeyboardScreen extends StatelessWidget {
     String altKey = altRow[keyIndex];
     bool isShiftPressed = (keyPressStates["LShift"] ?? false) ||
         (keyPressStates["RShift"] ?? false);
-    if (isShiftPressed) {
+    if (isShiftPressed && reactiveShiftEnabled) {
       if (customShiftMappings != null &&
           customShiftMappings!.containsKey(altKey)) {
         altKey = customShiftMappings![altKey]!;

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -30,7 +30,8 @@ class PreferencesScreen extends StatefulWidget {
   State<PreferencesScreen> createState() => _PreferencesScreenState();
 }
 
-class _PreferencesScreenState extends State<PreferencesScreen> with WindowListener {
+class _PreferencesScreenState extends State<PreferencesScreen>
+    with WindowListener {
   final PreferencesService _prefsService = PreferencesService();
 
   // UI state
@@ -41,6 +42,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
   // General settings
   bool _launchAtStartup = false;
   bool _autoHideEnabled = false;
+  bool _reactiveShiftEnabled = true;
   double _autoHideDuration = 2.0;
   double _opacity = 0.6;
   String _keyboardLayoutName = 'QWERTY';
@@ -210,6 +212,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
       // General settings
       _launchAtStartup = prefs['launchAtStartup'];
       _autoHideEnabled = prefs['autoHideEnabled'];
+      _reactiveShiftEnabled = prefs['reactiveShiftEnabled'];
       _autoHideDuration = prefs['autoHideDuration'];
       _opacity = prefs['opacity'];
       _keyboardLayoutName = prefs['keyboardLayoutName'];
@@ -269,8 +272,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
       _enableAutoHideHotKey = prefs['enableAutoHideHotKey'] ?? true;
       _enableToggleMoveHotKey = prefs['enableToggleMoveHotKey'] ?? true;
       _enablePreferencesHotKey = prefs['enablePreferencesHotKey'] ?? true;
-      _enableIncreaseOpacityHotKey = prefs['enableIncreaseOpacityHotKey'] ?? true;
-      _enableDecreaseOpacityHotKey = prefs['enableDecreaseOpacityHotKey'] ?? true;
+      _enableIncreaseOpacityHotKey =
+          prefs['enableIncreaseOpacityHotKey'] ?? true;
+      _enableDecreaseOpacityHotKey =
+          prefs['enableDecreaseOpacityHotKey'] ?? true;
 
       // Learn settings
       _learningModeEnabled = prefs['learningModeEnabled'] ?? false;
@@ -299,6 +304,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
       // General settings
       'launchAtStartup': _launchAtStartup,
       'autoHideEnabled': _autoHideEnabled,
+      'reactiveShiftEnabled': _reactiveShiftEnabled,
       'autoHideDuration': _autoHideDuration,
       'opacity': _opacity,
       'keyboardLayoutName': _keyboardLayoutName,
@@ -420,7 +426,8 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
         return KeyboardListener(
           focusNode: keyboardFocusNode,
           onKeyEvent: (KeyEvent keyEvent) {
-            if (keyEvent is KeyDownEvent && keyEvent.logicalKey == LogicalKeyboardKey.escape) {
+            if (keyEvent is KeyDownEvent &&
+                keyEvent.logicalKey == LogicalKeyboardKey.escape) {
               DesktopMultiWindow.invokeMethod(0, 'closePreferencesWindow');
             }
           },
@@ -434,7 +441,8 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
                     children: [
                       Expanded(
                         child: SingleChildScrollView(
-                          padding: const EdgeInsets.fromLTRB(20.0, 40.0, 20.0, 20.0),
+                          padding:
+                              const EdgeInsets.fromLTRB(20.0, 40.0, 20.0, 20.0),
                           child: _buildCurrentTabContent(),
                         ),
                       ),
@@ -456,7 +464,8 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
 
     return Container(
       width: drawerWidth,
-      color: Theme.of(context).drawerTheme.backgroundColor ?? colorScheme.surfaceContainer,
+      color: Theme.of(context).drawerTheme.backgroundColor ??
+          colorScheme.surfaceContainer,
       alignment: Alignment.center,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -503,14 +512,18 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
         child: ListTile(
           leading: Icon(
             _getIconForTab(tabName).icon,
-            color: isSelected ? colorScheme.primary : colorScheme.onSurfaceVariant.withAlpha(192),
+            color: isSelected
+                ? colorScheme.primary
+                : colorScheme.onSurfaceVariant.withAlpha(192),
           ),
           title: Text(
             tabName,
             style: TextStyle(
               fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
               fontSize: 16,
-              color: isSelected ? colorScheme.primary : colorScheme.onSurfaceVariant.withAlpha(192),
+              color: isSelected
+                  ? colorScheme.primary
+                  : colorScheme.onSurfaceVariant.withAlpha(192),
             ),
           ),
           onTap: () {
@@ -556,6 +569,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
           launchAtStartup: _launchAtStartup,
           autoHideEnabled: _autoHideEnabled,
           autoHideDuration: _autoHideDuration,
+          reactiveShiftEnabled: _reactiveShiftEnabled,
           keyboardLayoutName: _keyboardLayoutName,
           opacity: _opacity,
           updateLaunchAtStartup: (value) {
@@ -565,6 +579,10 @@ class _PreferencesScreenState extends State<PreferencesScreen> with WindowListen
           updateAutoHideEnabled: (value) {
             setState(() => _autoHideEnabled = value);
             _updateMainWindow('updateAutoHideEnabled', value);
+          },
+          updateReactiveShiftEnabled: (value) {
+            setState(() => _reactiveShiftEnabled = value);
+            _updateMainWindow('updateReactiveShiftEnabled', value);
           },
           updateAutoHideDuration: (value) {
             double roundedValue = (value * 2).round() / 2;

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -9,6 +9,7 @@ class PreferencesService {
   // General settings
   Future<bool> getLaunchAtStartup() async => await _prefs.getBool('launchAtStartup') ?? false;
   Future<bool> getAutoHideEnabled() async => await _prefs.getBool('autoHideEnabled') ?? false;
+  Future<bool> getReactiveShiftEnabled() async => await _prefs.getBool('reactiveShiftEnabled') ?? true;
   Future<double> getAutoHideDuration() async => await _prefs.getDouble('autoHideDuration') ?? 2.0;
   Future<double> getOpacity() async => await _prefs.getDouble('opacity') ?? 0.6;
   Future<String> getKeyboardLayoutName() async => await _prefs.getString('layout') ?? 'QWERTY';
@@ -144,6 +145,8 @@ class PreferencesService {
       await _prefs.setBool('launchAtStartup', value);
   Future<void> setAutoHideEnabled(bool value) async =>
       await _prefs.setBool('autoHideEnabled', value);
+  Future<void> setReactiveShiftEnabled(bool value) async =>
+      await _prefs.setBool('reactiveShiftEnabled', value);
   Future<void> setAutoHideDuration(double value) async =>
       await _prefs.setDouble('autoHideDuration', value);
   Future<void> setOpacity(double value) async => await _prefs.setDouble('opacity', value);
@@ -289,6 +292,7 @@ class PreferencesService {
   Future<Map<String, dynamic>> _loadGeneralPreferences() async => {
         'launchAtStartup': await getLaunchAtStartup(),
         'autoHideEnabled': await getAutoHideEnabled(),
+        'reactiveShiftEnabled': await getReactiveShiftEnabled(),
         'autoHideDuration': await getAutoHideDuration(),
         'opacity': await getOpacity(),
         'keyboardLayoutName': await getKeyboardLayoutName(),
@@ -384,6 +388,7 @@ class PreferencesService {
     // General settings
     await setLaunchAtStartup(prefs['launchAtStartup']);
     await setAutoHideEnabled(prefs['autoHideEnabled']);
+    await setReactiveShiftEnabled(prefs['reactiveShiftEnabled']);
     await setAutoHideDuration(prefs['autoHideDuration']);
     await setOpacity(prefs['opacity']);
     await setKeyboardLayoutName(prefs['keyboardLayoutName']);

--- a/lib/widgets/tabs/general_tab.dart
+++ b/lib/widgets/tabs/general_tab.dart
@@ -74,8 +74,9 @@ class _GeneralTabState extends State<GeneralTab> {
           onChanged: widget.updateAutoHideEnabled,
         ),
         ToggleOption(
-          label: 'Reactive Shift (update keys when Shift is pressed)',
+          label: 'Enable Reactive Shift',
           value: widget.reactiveShiftEnabled,
+          subtitle: 'Updates the displayed keys to their Shift+Key symbols when Shift is pressed',
           onChanged: widget.updateReactiveShiftEnabled,
         ),
         AnimatedCrossFade(

--- a/lib/widgets/tabs/general_tab.dart
+++ b/lib/widgets/tabs/general_tab.dart
@@ -5,11 +5,13 @@ import 'package:overkeys/models/keyboard_layouts.dart';
 class GeneralTab extends StatefulWidget {
   final bool launchAtStartup;
   final bool autoHideEnabled;
+  final bool reactiveShiftEnabled;
   final double autoHideDuration;
   final String keyboardLayoutName;
   final double opacity;
   final Function(bool) updateLaunchAtStartup;
   final Function(bool) updateAutoHideEnabled;
+  final Function(bool) updateReactiveShiftEnabled;
   final Function(double) updateAutoHideDuration;
   final Function(String) updateKeyboardLayoutName;
   final Function(double) updateOpacity;
@@ -18,11 +20,13 @@ class GeneralTab extends StatefulWidget {
     super.key,
     required this.launchAtStartup,
     required this.autoHideEnabled,
+    required this.reactiveShiftEnabled,
     required this.autoHideDuration,
     required this.keyboardLayoutName,
     required this.opacity,
     required this.updateLaunchAtStartup,
     required this.updateAutoHideEnabled,
+    required this.updateReactiveShiftEnabled,
     required this.updateAutoHideDuration,
     required this.updateKeyboardLayoutName,
     required this.updateOpacity,
@@ -68,6 +72,11 @@ class _GeneralTabState extends State<GeneralTab> {
           label: 'Auto-hide keyboard',
           value: widget.autoHideEnabled,
           onChanged: widget.updateAutoHideEnabled,
+        ),
+        ToggleOption(
+          label: 'Reactive Shift (update keys when Shift is pressed)',
+          value: widget.reactiveShiftEnabled,
+          onChanged: widget.updateReactiveShiftEnabled,
         ),
         AnimatedCrossFade(
           duration: const Duration(milliseconds: 300),


### PR DESCRIPTION
This PR adds the option to turn off or turn on the reactive shift behavior by adding the `reactiveShiftEnabled` boolean. By default, the setting's value is set to `true`. This addresses issue #117.

When turned off, keys would not rerender to show their shifted counterparts when the Shift key modifier is pressed.