### PR TITLE
fix: streamline key index adjustment for 6-column layout

### DIFF
--- a/lib/screens/keyboard_screen.dart
+++ b/lib/screens/keyboard_screen.dart
@@ -207,9 +207,7 @@ class KeyboardScreen extends StatelessWidget {
     String keyStateKey = Mappings.getKeyForSymbol(realKey);
     bool isPressed = keyPressStates[keyStateKey] ?? false;
 
-    if (use6ColLayout) {
-      keyIndex -= 1;
-    }
+    keyIndex -= use6ColLayout ? 1 : 0;
     Color keyColor;
     if (isPressed) {
       keyColor = keyColorPressed;
@@ -436,6 +434,7 @@ class KeyboardScreen extends StatelessWidget {
   }
 
   String _getAltLayoutKey(int rowIndex, int keyIndex) {
+    keyIndex += use6ColLayout ? 1 : 0;
     if (altLayout == null || rowIndex >= altLayout!.keys.length) {
       return "";
     }


### PR DESCRIPTION
This fixes issue #134, which was caused by a prior commit that prematurely adjusted the `keyIndex` for learning mode coloring. This change now corrects the `keyIndex` by accounting for that prior adjustment when retrieving the key from the alternative layout.