### PR TITLE
feat: add option to make OverKeys hidden on startup

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -49,6 +49,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   // General settings
   bool _launchAtStartup = false;
+  bool _hideAtStartup = false;
   bool _autoHideEnabled = false;
   bool _reactiveShiftEnabled = true;
   double _autoHideDuration = 2.0;
@@ -230,13 +231,14 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     setState(() {
       // General settings
       _launchAtStartup = prefs['launchAtStartup'];
+      _hideAtStartup = prefs['hideAtStartup'];
       _autoHideEnabled = prefs['autoHideEnabled'];
       _reactiveShiftEnabled = prefs['reactiveShiftEnabled'];
       _autoHideDuration = prefs['autoHideDuration'];
       _opacity = prefs['opacity'];
       _lastOpacity = prefs['opacity'];
-      _keyboardLayout =
-          availableLayouts.firstWhere((layout) => layout.name == prefs['keyboardLayoutName']);
+      _keyboardLayout = availableLayouts
+          .firstWhere((layout) => layout.name == prefs['keyboardLayoutName']);
       _initialKeyboardLayout = _keyboardLayout;
 
       // Keyboard settings
@@ -294,8 +296,10 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       _enableAutoHideHotKey = prefs['enableAutoHideHotKey'] ?? true;
       _enableToggleMoveHotKey = prefs['enableToggleMoveHotKey'] ?? true;
       _enablePreferencesHotKey = prefs['enablePreferencesHotKey'] ?? true;
-      _enableIncreaseOpacityHotKey = prefs['enableIncreaseOpacityHotKey'] ?? true;
-      _enableDecreaseOpacityHotKey = prefs['enableDecreaseOpacityHotKey'] ?? true;
+      _enableIncreaseOpacityHotKey =
+          prefs['enableIncreaseOpacityHotKey'] ?? true;
+      _enableDecreaseOpacityHotKey =
+          prefs['enableDecreaseOpacityHotKey'] ?? true;
 
       // Learn settings
       _learningModeEnabled = prefs['learningModeEnabled'];
@@ -323,6 +327,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     final prefs = {
       // General settings
       'launchAtStartup': _launchAtStartup,
+      'hideAtStartup': _hideAtStartup,
       'autoHideEnabled': _autoHideEnabled,
       'reactiveShiftEnabled': _reactiveShiftEnabled,
       'autoHideDuration': _autoHideDuration,
@@ -538,10 +543,12 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   Future<void> _adjustWindowSize() async {
     _fadeIn();
-    double height =
-        _showTopRow ? _defaultWindowHeight + _defaultTopRowExtraHeight : _defaultWindowHeight;
-    double width =
-        _showTopRow ? _defaultWindowWidth + _defaultTopRowExtraWidth : _defaultWindowWidth;
+    double height = _showTopRow
+        ? _defaultWindowHeight + _defaultTopRowExtraHeight
+        : _defaultWindowHeight;
+    double width = _showTopRow
+        ? _defaultWindowWidth + _defaultTopRowExtraWidth
+        : _defaultWindowWidth;
     await windowManager.setSize(Size(width, height));
     await windowManager.setAlignment(Alignment.bottomCenter);
   }
@@ -566,7 +573,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   void _setupKeyListener() {
     final receivePort = ReceivePort();
-    Isolate.spawn(setHook, receivePort.sendPort).then((_) {}).catchError((error) {
+    Isolate.spawn(setHook, receivePort.sendPort)
+        .then((_) {})
+        .catchError((error) {
       if (kDebugMode) {
         print('Error spawning Isolate: $error');
       }
@@ -640,8 +649,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     if (!_autoHideEnabled) return;
 
     _autoHideTimer?.cancel();
-    _autoHideTimer =
-        Timer(Duration(milliseconds: (_autoHideDuration * 1000).round()), _handleAutoHide);
+    _autoHideTimer = Timer(
+        Duration(milliseconds: (_autoHideDuration * 1000).round()),
+        _handleAutoHide);
   }
 
   void _handleAutoHide() {
@@ -662,11 +672,15 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         }
       }
     });
-    _showOverlay(_autoHideEnabled ? 'Auto-hide Enabled' : 'Auto-hide Disabled',
-        _autoHideEnabled ? const Icon(LucideIcons.timerReset) : const Icon(LucideIcons.timerOff));
+    _showOverlay(
+        _autoHideEnabled ? 'Auto-hide Enabled' : 'Auto-hide Disabled',
+        _autoHideEnabled
+            ? const Icon(LucideIcons.timerReset)
+            : const Icon(LucideIcons.timerOff));
     DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
       for (final id in windowIds) {
-        DesktopMultiWindow.invokeMethod(id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
+        DesktopMultiWindow.invokeMethod(
+            id, 'updateAutoHideFromMainWindow', _autoHideEnabled);
       }
     });
     _saveAllPreferences();
@@ -685,8 +699,11 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         _lastOpacity = newLastOpacity;
       });
 
-      _showOverlay('Opacity: ${(_lastOpacity * 100).round()}%',
-          increase ? const Icon(LucideIcons.plusCircle) : const Icon(LucideIcons.minusCircle));
+      _showOverlay(
+          'Opacity: ${(_lastOpacity * 100).round()}%',
+          increase
+              ? const Icon(LucideIcons.plusCircle)
+              : const Icon(LucideIcons.minusCircle));
     }
 
     _opacityDebounceTimer?.cancel();
@@ -698,7 +715,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         _saveAllPreferences();
         DesktopMultiWindow.getAllSubWindowIds().then((windowIds) {
           for (final id in windowIds) {
-            DesktopMultiWindow.invokeMethod(id, 'updateOpacityFromMainWindow', _opacity);
+            DesktopMultiWindow.invokeMethod(
+                id, 'updateOpacityFromMainWindow', _opacity);
           }
         });
       }
@@ -740,8 +758,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   Future<void> _setupTray() async {
-    final String iconPath =
-        Platform.isWindows ? 'assets/images/app_icon.ico' : 'assets/images/app_icon.png';
+    final String iconPath = Platform.isWindows
+        ? 'assets/images/app_icon.ico'
+        : 'assets/images/app_icon.png';
     await Future.wait([
       trayManager.setIcon(iconPath),
       trayManager.setToolTip('OverKeys'),
@@ -749,7 +768,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     trayManager.setContextMenu(Menu(items: [
       MenuItem.checkbox(
         key: 'toggle_mouse_events',
-        label: 'Move\t${_formatHotkey(_toggleMoveHotKey, _enableToggleMoveHotKey)}',
+        label:
+            'Move\t${_formatHotkey(_toggleMoveHotKey, _enableToggleMoveHotKey)}',
         checked: !_ignoreMouseEvents,
         onClick: (menuItem) {
           setState(() {
@@ -767,7 +787,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       MenuItem.separator(),
       MenuItem.checkbox(
         key: 'toggle_auto_hide',
-        label: 'Auto Hide\t${_formatHotkey(_autoHideHotKey, _enableAutoHideHotKey)}',
+        label:
+            'Auto Hide\t${_formatHotkey(_autoHideHotKey, _enableAutoHideHotKey)}',
         checked: _autoHideEnabled,
         onClick: (menuItem) {
           _toggleAutoHide(!_autoHideEnabled);
@@ -784,7 +805,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       MenuItem.separator(),
       MenuItem(
         key: 'preferences',
-        label: 'Preferences\t${_formatHotkey(_preferencesHotKey, _enablePreferencesHotKey)}',
+        label:
+            'Preferences\t${_formatHotkey(_preferencesHotKey, _enablePreferencesHotKey)}',
         onClick: (menuItem) {
           _showPreferences();
         },
@@ -792,7 +814,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       MenuItem.separator(),
       MenuItem(
         key: 'toggle_visibility',
-        label: 'Hide/Show\t${_formatHotkey(_visibilityHotKey, _enableVisibilityHotKey)}',
+        label:
+            'Hide/Show\t${_formatHotkey(_visibilityHotKey, _enableVisibilityHotKey)}',
         onClick: (menuItem) {
           onTrayIconMouseDown();
         },
@@ -874,9 +897,11 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         _preferencesHotKey,
         keyDownHandler: (hotKey) {
           if (kDebugMode) {
-            print('Preferences hotkey triggered. Opening/Focusing Preferences Window.');
+            print(
+                'Preferences hotkey triggered. Opening/Focusing Preferences Window.');
           }
-          _showOverlay('Opening Preferences', const Icon(LucideIcons.appWindow));
+          _showOverlay(
+              'Opening Preferences', const Icon(LucideIcons.appWindow));
           _showPreferences();
         },
       );
@@ -933,8 +958,11 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   @override
   void onTrayIconMouseDown() {
     _forceHide = !_forceHide;
-    _showOverlay(_forceHide ? 'Keyboard Hidden' : 'Keyboard Shown',
-        _forceHide ? const Icon(LucideIcons.eyeOff) : const Icon(LucideIcons.eye));
+    _showOverlay(
+        _forceHide ? 'Keyboard Hidden' : 'Keyboard Shown',
+        _forceHide
+            ? const Icon(LucideIcons.eyeOff)
+            : const Icon(LucideIcons.eye));
     if (_isWindowVisible) {
       _fadeOut();
     } else {
@@ -962,7 +990,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
       for (int id in windowIds) {
         Map<String, dynamic>? windowData;
         try {
-          String? dataString = await DesktopMultiWindow.invokeMethod(id, 'getWindowType');
+          String? dataString =
+              await DesktopMultiWindow.invokeMethod(id, 'getWindowType');
           if (dataString != null) {
             windowData = jsonDecode(dataString);
             if (windowData != null && windowData['type'] == 'preferences') {
@@ -999,6 +1028,9 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
             _launchAtStartup = launchAtStartupValue;
             _handleStartupToggle(launchAtStartupValue);
           });
+        case 'updateHideAtStartup':
+          final hideAtStartup = call.arguments as bool;
+          setState(() => _hideAtStartup = hideAtStartup);
         case 'updateAutoHideEnabled':
           final autoHideEnabled = call.arguments as bool;
           _toggleAutoHide(autoHideEnabled);
@@ -1017,11 +1049,13 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
         case 'updateLayout':
           final layoutName = call.arguments as String;
           setState(() {
-            if ((_kanataEnabled || _useUserLayout) && _advancedSettingsEnabled) {
-              _initialKeyboardLayout =
-                  availableLayouts.firstWhere((layout) => layout.name == layoutName);
+            if ((_kanataEnabled || _useUserLayout) &&
+                _advancedSettingsEnabled) {
+              _initialKeyboardLayout = availableLayouts
+                  .firstWhere((layout) => layout.name == layoutName);
             } else {
-              _keyboardLayout = availableLayouts.firstWhere((layout) => layout.name == layoutName);
+              _keyboardLayout = availableLayouts
+                  .firstWhere((layout) => layout.name == layoutName);
               _initialKeyboardLayout = _keyboardLayout;
             }
           });
@@ -1121,13 +1155,15 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
           setState(() => _keyTextColor = Color(keyTextColor));
         case 'updateKeyTextColorNotPressed':
           final keyTextColorNotPressed = call.arguments as int;
-          setState(() => _keyTextColorNotPressed = Color(keyTextColorNotPressed));
+          setState(
+              () => _keyTextColorNotPressed = Color(keyTextColorNotPressed));
         case 'updateKeyBorderColorPressed':
           final keyBorderColorPressed = call.arguments as int;
           setState(() => _keyBorderColorPressed = Color(keyBorderColorPressed));
         case 'updateKeyBorderColorNotPressed':
           final keyBorderColorNotPressed = call.arguments as int;
-          setState(() => _keyBorderColorNotPressed = Color(keyBorderColorNotPressed));
+          setState(() =>
+              _keyBorderColorNotPressed = Color(keyBorderColorNotPressed));
 
         // Animations settings
         case 'updateAnimationEnabled':

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -197,6 +197,8 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
     }
     if (_autoHideEnabled) {
       _resetAutoHideTimer();
+    } else if (_hideAtStartup) {
+      onTrayIconMouseDown();
     }
   }
 

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -41,6 +41,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
 
   // General settings
   bool _launchAtStartup = false;
+  bool _hideAtStartup = false;
   bool _autoHideEnabled = false;
   bool _reactiveShiftEnabled = true;
   double _autoHideDuration = 2.0;
@@ -211,6 +212,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     setState(() {
       // General settings
       _launchAtStartup = prefs['launchAtStartup'];
+      _hideAtStartup = prefs['hideAtStartup'];
       _autoHideEnabled = prefs['autoHideEnabled'];
       _reactiveShiftEnabled = prefs['reactiveShiftEnabled'];
       _autoHideDuration = prefs['autoHideDuration'];
@@ -303,6 +305,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
     final prefs = {
       // General settings
       'launchAtStartup': _launchAtStartup,
+      'hideAtStartup': _hideAtStartup,
       'autoHideEnabled': _autoHideEnabled,
       'reactiveShiftEnabled': _reactiveShiftEnabled,
       'autoHideDuration': _autoHideDuration,
@@ -567,6 +570,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       case 'General':
         return GeneralTab(
           launchAtStartup: _launchAtStartup,
+          hideAtStartup: _hideAtStartup,
           autoHideEnabled: _autoHideEnabled,
           autoHideDuration: _autoHideDuration,
           reactiveShiftEnabled: _reactiveShiftEnabled,
@@ -575,6 +579,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updateLaunchAtStartup: (value) {
             setState(() => _launchAtStartup = value);
             _updateMainWindow('updateLaunchAtStartup', value);
+          },
+          updateHideAtStartup: (value) {
+            setState(() => _hideAtStartup = value);
+            _updateMainWindow('updateHideAtStartup', value);
           },
           updateAutoHideEnabled: (value) {
             setState(() => _autoHideEnabled = value);

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -8,6 +8,7 @@ class PreferencesService {
 
   // General settings
   Future<bool> getLaunchAtStartup() async => await _prefs.getBool('launchAtStartup') ?? false;
+  Future<bool> getHideAtStartup() async => await _prefs.getBool('hideAtStartup') ?? false;
   Future<bool> getAutoHideEnabled() async => await _prefs.getBool('autoHideEnabled') ?? false;
   Future<bool> getReactiveShiftEnabled() async => await _prefs.getBool('reactiveShiftEnabled') ?? true;
   Future<double> getAutoHideDuration() async => await _prefs.getDouble('autoHideDuration') ?? 2.0;
@@ -143,6 +144,8 @@ class PreferencesService {
   // General settings
   Future<void> setLaunchAtStartup(bool value) async =>
       await _prefs.setBool('launchAtStartup', value);
+  Future<void> setHideAtStartup(bool value) async =>
+      await _prefs.setBool('hideAtStartup', value);
   Future<void> setAutoHideEnabled(bool value) async =>
       await _prefs.setBool('autoHideEnabled', value);
   Future<void> setReactiveShiftEnabled(bool value) async =>
@@ -291,6 +294,7 @@ class PreferencesService {
 
   Future<Map<String, dynamic>> _loadGeneralPreferences() async => {
         'launchAtStartup': await getLaunchAtStartup(),
+        'hideAtStartup': await getHideAtStartup(),
         'autoHideEnabled': await getAutoHideEnabled(),
         'reactiveShiftEnabled': await getReactiveShiftEnabled(),
         'autoHideDuration': await getAutoHideDuration(),
@@ -387,6 +391,7 @@ class PreferencesService {
   Future<void> saveAllPreferences(Map<String, dynamic> prefs) async {
     // General settings
     await setLaunchAtStartup(prefs['launchAtStartup']);
+    await setHideAtStartup(prefs['hideAtStartup']);
     await setAutoHideEnabled(prefs['autoHideEnabled']);
     await setReactiveShiftEnabled(prefs['reactiveShiftEnabled']);
     await setAutoHideDuration(prefs['autoHideDuration']);

--- a/lib/widgets/tabs/general_tab.dart
+++ b/lib/widgets/tabs/general_tab.dart
@@ -4,12 +4,14 @@ import 'package:overkeys/models/keyboard_layouts.dart';
 
 class GeneralTab extends StatefulWidget {
   final bool launchAtStartup;
+  final bool hideAtStartup;
   final bool autoHideEnabled;
   final bool reactiveShiftEnabled;
   final double autoHideDuration;
   final String keyboardLayoutName;
   final double opacity;
   final Function(bool) updateLaunchAtStartup;
+  final Function(bool) updateHideAtStartup;
   final Function(bool) updateAutoHideEnabled;
   final Function(bool) updateReactiveShiftEnabled;
   final Function(double) updateAutoHideDuration;
@@ -19,12 +21,14 @@ class GeneralTab extends StatefulWidget {
   const GeneralTab({
     super.key,
     required this.launchAtStartup,
+    required this.hideAtStartup,
     required this.autoHideEnabled,
     required this.reactiveShiftEnabled,
     required this.autoHideDuration,
     required this.keyboardLayoutName,
     required this.opacity,
     required this.updateLaunchAtStartup,
+    required this.updateHideAtStartup,
     required this.updateAutoHideEnabled,
     required this.updateReactiveShiftEnabled,
     required this.updateAutoHideDuration,
@@ -76,12 +80,17 @@ class _GeneralTabState extends State<GeneralTab> {
         ToggleOption(
           label: 'Enable Reactive Shift',
           value: widget.reactiveShiftEnabled,
-          subtitle: 'Updates the displayed keys to their Shift+Key symbols when Shift is pressed',
+          subtitle:
+              'Updates the displayed keys to their Shift+Key symbols when Shift is pressed',
           onChanged: widget.updateReactiveShiftEnabled,
         ),
         AnimatedCrossFade(
           duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox.shrink(),
+          firstChild: ToggleOption(
+            label: 'Start hidden',
+            value: widget.hideAtStartup,
+            onChanged: widget.updateHideAtStartup,
+          ),
           secondChild: SliderOption(
             label: 'Auto-hide duration (seconds)',
             value: _localAutoHideDuration,


### PR DESCRIPTION
This addresses issue #123. With the "Start hidden" toggle, even if auto-hide is off, OverKeys would start hidden on app open.