### PR TITLE
feat: implement locales through customKeys in user config

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -183,6 +183,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   Future<void> _initialize() async {
     await _loadAllPreferences();
+    await initializeKeyMaps();
     trayManager.addListener(this);
     windowManager.addListener(this);
     _setupTray();

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -183,7 +183,6 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
 
   Future<void> _initialize() async {
     await _loadAllPreferences();
-    await initializeKeyMaps();
     trayManager.addListener(this);
     windowManager.addListener(this);
     _setupTray();
@@ -420,6 +419,7 @@ class _MainAppState extends State<MainApp> with TrayListener, WindowListener {
   }
 
   Future<void> _loadConfiguration() async {
+    await loadCustomKeys();
     await _loadCustomShiftMappings();
     if (_advancedSettingsEnabled) {
       if (_useUserLayout) {

--- a/lib/models/mappings.dart
+++ b/lib/models/mappings.dart
@@ -1,3 +1,4 @@
+import '../utils/key_code.dart';
 // https://github.com/jtroo/kanata/blob/a9dabfcb07e22c9efa0bc15349780b10afacb6cd/parser/src/keys/mod.rs as guide
 
 class Mappings {
@@ -143,30 +144,15 @@ class Mappings {
   }
 
   static String? getShiftedSymbol(String symbol) {
-    const Map<String, String> shiftedSymbols = {
-      '`': '~',
-      '1': '!',
-      '2': '@',
-      '3': '#',
-      '4': '\$',
-      '5': '%',
-      '6': '^',
-      '7': '&',
-      '8': '*',
-      '9': '(',
-      '0': ')',
-      '-': '_',
-      '=': '+',
-      '[': '{',
-      ']': '}',
-      '\\': '|',
-      ';': ':',
-      '\'': '"',
-      ',': '<',
-      '.': '>',
-      '/': '?'
-    };
-
-    return shiftedSymbols[symbol] ?? symbol;
+    for (final entry in activeKeyCodeShiftMap.entries) {
+      final key = entry.key;
+      if (key.$2 == false) {
+        final shifted = activeKeyCodeShiftMap[(key.$1, true)];
+        if (entry.value == symbol && shifted != null) {
+          return shifted;
+        }
+      }
+    }
+    return symbol;
   }
 }

--- a/lib/models/user_config.dart
+++ b/lib/models/user_config.dart
@@ -5,7 +5,7 @@ class UserConfig {
   String? altLayout;
   String? customFont;
   List<KeyboardLayout>? userLayouts;
-  Map<String, String> customShiftMappings;
+  Map<String, String>? customShiftMappings;
   String? kanataHost;
   int? kanataPort;
 
@@ -14,7 +14,7 @@ class UserConfig {
     this.altLayout,
     this.customFont,
     this.userLayouts,
-    Map<String, String>? customShiftMappings,
+    this.customShiftMappings,
     this.kanataHost,
     this.kanataPort,
   }) : customShiftMappings = customShiftMappings ?? {};
@@ -68,7 +68,8 @@ class UserConfig {
       if (altLayout != null) 'altLayout': altLayout,
       if (customFont != null) 'customFont': customFont,
       if (userLayoutsJson.isNotEmpty) 'userLayouts': userLayoutsJson,
-      if (customShiftMappings.isNotEmpty) 'customShiftMappings': customShiftMappings,
+      if (customShiftMappings != null && customShiftMappings!.isNotEmpty)
+        'customShiftMappings': customShiftMappings,
       if (kanataHost != null) 'kanataHost': kanataHost,
       if (kanataPort != null) 'kanataPort': kanataPort,
     };

--- a/lib/models/user_config.dart
+++ b/lib/models/user_config.dart
@@ -8,6 +8,7 @@ class UserConfig {
   Map<String, String>? customShiftMappings;
   String? kanataHost;
   int? kanataPort;
+  Map<String, dynamic>? customKeys;
 
   UserConfig({
     this.defaultUserLayout,
@@ -17,7 +18,8 @@ class UserConfig {
     this.customShiftMappings,
     this.kanataHost,
     this.kanataPort,
-  }) : customShiftMappings = customShiftMappings ?? {};
+    this.customKeys,
+  });
 
   factory UserConfig.fromJson(Map<String, dynamic> json) {
     List<KeyboardLayout> userLayouts = [];
@@ -40,6 +42,11 @@ class UserConfig {
           Map<String, String>.from(json['customShiftMappings']);
     }
 
+    Map<String, dynamic>? customKeys;
+    if (json['customKeys'] != null) {
+      customKeys = Map<String, dynamic>.from(json['customKeys']);
+    }
+
     return UserConfig(
       defaultUserLayout: json['defaultUserLayout'],
       altLayout: json['altLayout'],
@@ -48,6 +55,7 @@ class UserConfig {
       customShiftMappings: customShiftMappings,
       kanataHost: json['kanataHost'],
       kanataPort: json['kanataPort'] != null ? json['kanataPort'] as int : null,
+      customKeys: customKeys,
     );
   }
 
@@ -72,6 +80,7 @@ class UserConfig {
         'customShiftMappings': customShiftMappings,
       if (kanataHost != null) 'kanataHost': kanataHost,
       if (kanataPort != null) 'kanataPort': kanataPort,
+      if (customKeys != null && customKeys!.isNotEmpty) '!': customKeys,
     };
   }
 }

--- a/lib/utils/key_code.dart
+++ b/lib/utils/key_code.dart
@@ -142,13 +142,11 @@ Map<(int, bool), String> defaultKeyCodeShiftMap = {
   (VK_OEM_MINUS, true): '_',
 };
 
-Map<int, String> activeKeyCodeMap = Map<int, String>.from(defaultKeyCodeMap);
 Map<(int, bool), String> activeKeyCodeShiftMap =
     Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
 
 Future<void> initializeKeyMaps() async {
   final config = await ConfigService().loadConfig();
-  activeKeyCodeMap = Map<int, String>.from(defaultKeyCodeMap);
   activeKeyCodeShiftMap = Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
 
   if (config.customKeys != null && config.customKeys!['keyCodeMap'] != null) {
@@ -157,12 +155,12 @@ Future<void> initializeKeyMaps() async {
       if (value is int) {
         activeKeyCodeShiftMap[(value, false)] = key.toString();
         activeKeyCodeShiftMap[(value, true)] = key.toString();
-        activeKeyCodeMap[value] = key.toString();
       }
     });
   }
 
-  if (config.customKeys != null && config.customKeys!['keyCodeShiftMap'] != null) {
+  if (config.customKeys != null &&
+      config.customKeys!['keyCodeShiftMap'] != null) {
     final rawMap = config.customKeys!['keyCodeShiftMap'] as Map;
     rawMap.forEach((key, value) {
       if (value is int) {
@@ -173,9 +171,5 @@ Future<void> initializeKeyMaps() async {
 }
 
 String getKeyFromKeyCodeShift(int keyCode, bool isShiftDown) {
-  final shiftKey = activeKeyCodeShiftMap[(keyCode, isShiftDown)];
-  if (shiftKey != null) return shiftKey;
-  final key = activeKeyCodeMap[keyCode];
-  if (key != null) return key;
-  return '';
+  return activeKeyCodeShiftMap[(keyCode, isShiftDown)] ?? defaultKeyCodeMap[keyCode] ?? '';
 }

--- a/lib/utils/key_code.dart
+++ b/lib/utils/key_code.dart
@@ -1,7 +1,8 @@
 import 'package:win32/win32.dart';
+import '../services/config_service.dart';
 
 // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-final Map<int, String> _keyCodeMap = {
+final Map<int, String> defaultKeyCodeMap = {
   VK_A: 'A',
   VK_B: 'B',
   VK_C: 'C',
@@ -96,7 +97,7 @@ final Map<int, String> _keyCodeMap = {
   VK_DIVIDE: '/',
 };
 
-final Map<(int, bool), String> _keyCodeShiftMap = {
+Map<(int, bool), String> defaultKeyCodeShiftMap = {
   (0x30, false): '0',
   (0x30, true): ')',
   (0x31, false): '1',
@@ -141,10 +142,39 @@ final Map<(int, bool), String> _keyCodeShiftMap = {
   (VK_OEM_MINUS, true): '_',
 };
 
+Map<int, String> activeKeyCodeMap = Map<int, String>.from(defaultKeyCodeMap);
+Map<(int, bool), String> activeKeyCodeShiftMap =
+    Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
+
+Future<void> initializeKeyMaps() async {
+  final config = await ConfigService().loadConfig();
+  activeKeyCodeMap = Map<int, String>.from(defaultKeyCodeMap);
+  activeKeyCodeShiftMap = Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
+
+  if (config.customKeys != null && config.customKeys!['keyCodeMap'] != null) {
+    final rawMap = config.customKeys!['keyCodeMap'] as Map;
+    rawMap.forEach((key, value) {
+      if (value is int) {
+        activeKeyCodeShiftMap[(value, false)] = key.toString();
+        activeKeyCodeMap[value] = key.toString();
+      }
+    });
+  }
+
+  if (config.customKeys != null && config.customKeys!['keyCodeShiftMap'] != null) {
+    final rawMap = config.customKeys!['keyCodeShiftMap'] as Map;
+    rawMap.forEach((key, value) {
+      if (value is int) {
+        activeKeyCodeShiftMap[(value, true)] = key.toString();
+      }
+    });
+  }
+}
+
 String getKeyFromKeyCodeShift(int keyCode, bool isShiftDown) {
-  final shiftKey = _keyCodeShiftMap[(keyCode, isShiftDown)];
+  final shiftKey = activeKeyCodeShiftMap[(keyCode, isShiftDown)];
   if (shiftKey != null) return shiftKey;
-  final key = _keyCodeMap[keyCode];
+  final key = activeKeyCodeMap[keyCode];
   if (key != null) return key;
   return '';
 }

--- a/lib/utils/key_code.dart
+++ b/lib/utils/key_code.dart
@@ -156,6 +156,7 @@ Future<void> initializeKeyMaps() async {
     rawMap.forEach((key, value) {
       if (value is int) {
         activeKeyCodeShiftMap[(value, false)] = key.toString();
+        activeKeyCodeShiftMap[(value, true)] = key.toString();
         activeKeyCodeMap[value] = key.toString();
       }
     });

--- a/lib/utils/key_code.dart
+++ b/lib/utils/key_code.dart
@@ -145,10 +145,8 @@ Map<(int, bool), String> defaultKeyCodeShiftMap = {
 Map<(int, bool), String> activeKeyCodeShiftMap =
     Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
 
-Future<void> initializeKeyMaps() async {
+Future<void> loadCustomKeys() async {
   final config = await ConfigService().loadConfig();
-  activeKeyCodeShiftMap = Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
-
   if (config.customKeys != null && config.customKeys!['keyCodeMap'] != null) {
     final rawMap = config.customKeys!['keyCodeMap'] as Map;
     rawMap.forEach((key, value) {
@@ -171,5 +169,7 @@ Future<void> initializeKeyMaps() async {
 }
 
 String getKeyFromKeyCodeShift(int keyCode, bool isShiftDown) {
-  return activeKeyCodeShiftMap[(keyCode, isShiftDown)] ?? defaultKeyCodeMap[keyCode] ?? '';
+  return activeKeyCodeShiftMap[(keyCode, isShiftDown)] ??
+      defaultKeyCodeMap[keyCode] ??
+      '';
 }

--- a/lib/utils/key_code.dart
+++ b/lib/utils/key_code.dart
@@ -147,6 +147,7 @@ Map<(int, bool), String> activeKeyCodeShiftMap =
 
 Future<void> loadCustomKeys() async {
   final config = await ConfigService().loadConfig();
+  activeKeyCodeShiftMap = Map<(int, bool), String>.from(defaultKeyCodeShiftMap);
   if (config.customKeys != null && config.customKeys!['keyCodeMap'] != null) {
     final rawMap = config.customKeys!['keyCodeMap'] as Map;
     rawMap.forEach((key, value) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,26 +273,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -606,10 +606,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   tray_manager:
     dependency: "direct main"
     description:
@@ -646,10 +646,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"
+      sha256: "199bc33e746088546a39cc5f36bac5a278c5e53b40cb3196f99e7345fdcfae6b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.20"
+    version: "6.3.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -710,18 +710,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   web:
     dependency: transitive
     description:
@@ -779,5 +779,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"


### PR DESCRIPTION
This solves issue #133. By defining `customKeys` in the user's `overkeys_config.json`, "foreign" keys are supported. However, it is still up to the user to either: 

1. Learn and define the key codes that the foreign keys use by building locally and inferring from the app's debug statements; or
2. Create a feature request to ask for help in defining these key codes, given that they state the keyboard they are using in Windows (e.g., US QWERTY, German QWERTZ)
3. Create a discussion to ask for help from the community.

The following is a sample `overkeys_config.json` that implements the new feature:
``` json
{
	"defaultUserLayout": "QWERTZ",
	"userLayouts": [
		{
			"name": "QWERTZ",
			"keys": [
				["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "BSPC", "DEL"],
				["TAB", "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "Ü", "+", "PGUP", "PGDN"],
				["A", "S", "D", "F", "G", "H", "J", "K", "L", "Ö", "Ä", "#", "ENTER", "HOME"],
				["LSFT", "<", "Y", "X", "C", "V", "B", "N", "M", ",", ".", "-", "↑", "RSFT"],
				["END", "LCTRL", "LALT", " ", "RALT", "RCTRL", "←", "↓", "→"]
			]
		}
	],
	"customKeys": {
		"keyCodeMap": {
			"Ü": 186,
			"+": 187,
			"#": 191,
			"Ö": 192,
			"ß": 219,
			"^": 220,
			"´": 221,
			"Ä": 222,
			"<": 226
		},
		"keyCodeShiftMap": {
			"=": 48,
			"!": 49,
			"\"": 50,
			"§": 51,
			"$": 52,
			"%": 53,
			"&": 54,
			"/": 55,
			"(": 56,
			")": 57,
			"*": 187,
			";": 188,
			":": 190,
			"'": 191,
			"?": 219,
			"°": 220,
			"`": 221,
			">": 226
		}
	}
}
```
`keyCodeShiftMap` is almost the same as `customShiftMappings` field, except the latter just visually changes the keys, while the former logically maps the shift symbol of the original key to the new one. As such, there is no need for duplication of entries between the two fields.

This PR also made the config file not have null values anymore by having null checks and making all fields optional, to keep the config cleaner.