### PR TITLE
feat: Add hide on default layer setting - Add new preference setting …

### DIFF
--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -143,6 +143,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
   bool _use6ColLayout = false;
   bool _kanataEnabled = false;
   bool _keyboardFollowsMouse = false;
+  bool _hideOnDefaultLayer = false;
 
   @override
   void initState() {
@@ -298,6 +299,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
       _use6ColLayout = prefs['use6ColLayout'];
       _kanataEnabled = prefs['kanataEnabled'];
       _keyboardFollowsMouse = prefs['keyboardFollowsMouse'] ?? false;
+      _hideOnDefaultLayer = prefs['hideOnDefaultLayer'] ?? false;
     });
   }
 
@@ -912,6 +914,7 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           use6ColLayout: _use6ColLayout,
           kanataEnabled: _kanataEnabled,
           keyboardFollowsMouse: _keyboardFollowsMouse,
+          hideOnDefaultLayer: _hideOnDefaultLayer,
           updateAdvancedSettingsEnabled: (value) {
             setState(() => _advancedSettingsEnabled = value);
             _updateMainWindow('updateAdvancedSettingsEnabled', value);
@@ -947,6 +950,10 @@ class _PreferencesScreenState extends State<PreferencesScreen>
           updateKeyboardFollowsMouse: (value) {
             setState(() => _keyboardFollowsMouse = value);
             _updateMainWindow('updateKeyboardFollowsMouse', value);
+          },
+          updateHideOnDefaultLayer: (value) {
+            setState(() => _hideOnDefaultLayer = value);
+            _updateMainWindow('updateHideOnDefaultLayer', value);
           },
         );
       case 'About':

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -140,6 +140,8 @@ class PreferencesService {
   Future<bool> getKanataEnabled() async => await _prefs.getBool('kanataEnabled') ?? false;
   Future<bool> getKeyboardFollowsMouse() async =>
       await _prefs.getBool('keyboardFollowsMouse') ?? false;
+  Future<bool> getHideOnDefaultLayer() async =>
+      await _prefs.getBool('hideOnDefaultLayer') ?? false;
 
   // General settings
   Future<void> setLaunchAtStartup(bool value) async =>
@@ -277,6 +279,8 @@ class PreferencesService {
   Future<void> setKanataEnabled(bool value) async => await _prefs.setBool('kanataEnabled', value);
   Future<void> setKeyboardFollowsMouse(bool value) async =>
       await _prefs.setBool('keyboardFollowsMouse', value);
+  Future<void> setHideOnDefaultLayer(bool value) async =>
+      await _prefs.setBool('hideOnDefaultLayer', value);
 
   Future<Map<String, dynamic>> loadAllPreferences() async {
     return {
@@ -386,6 +390,7 @@ class PreferencesService {
         'use6ColLayout': await getUse6ColLayout(),
         'kanataEnabled': await getKanataEnabled(),
         'keyboardFollowsMouse': await getKeyboardFollowsMouse(),
+        'hideOnDefaultLayer': await getHideOnDefaultLayer(),
       };
 
   Future<void> saveAllPreferences(Map<String, dynamic> prefs) async {
@@ -475,5 +480,6 @@ class PreferencesService {
     await setUse6ColLayout(prefs['use6ColLayout']);
     await setKanataEnabled(prefs['kanataEnabled']);
     await setKeyboardFollowsMouse(prefs['keyboardFollowsMouse']);
+    await setHideOnDefaultLayer(prefs['hideOnDefaultLayer']);
   }
 }

--- a/lib/widgets/tabs/advanced_tab.dart
+++ b/lib/widgets/tabs/advanced_tab.dart
@@ -13,6 +13,7 @@ class AdvancedTab extends StatelessWidget {
   final bool use6ColLayout;
   final bool kanataEnabled;
   final bool keyboardFollowsMouse;
+  final bool hideOnDefaultLayer;
   final Function(bool) updateAdvancedSettingsEnabled;
   final Function(bool) updateUseUserLayout;
   final Function(bool) updateShowAltLayout;
@@ -20,6 +21,7 @@ class AdvancedTab extends StatelessWidget {
   final Function(bool) updateUse6ColLayout;
   final Function(bool) updateKanataEnabled;
   final Function(bool) updateKeyboardFollowsMouse;
+  final Function(bool) updateHideOnDefaultLayer;
 
   const AdvancedTab({
     super.key,
@@ -30,6 +32,7 @@ class AdvancedTab extends StatelessWidget {
     required this.use6ColLayout,
     required this.kanataEnabled,
     required this.keyboardFollowsMouse,
+    required this.hideOnDefaultLayer,
     required this.updateAdvancedSettingsEnabled,
     required this.updateUseUserLayout,
     required this.updateShowAltLayout,
@@ -37,6 +40,7 @@ class AdvancedTab extends StatelessWidget {
     required this.updateUse6ColLayout,
     required this.updateKanataEnabled,
     required this.updateKeyboardFollowsMouse,
+    required this.updateHideOnDefaultLayer,
   });
 
   @override
@@ -105,6 +109,13 @@ class AdvancedTab extends StatelessWidget {
                 subtitle:
                     'EXPERIMENTAL: Keyboard will follow your mouse cursor across monitors. Note: This will override manual position adjustments. Also causes focus issues',
                 onChanged: updateKeyboardFollowsMouse,
+              ),
+              ToggleOption(
+                label: 'Hide on default layer',
+                value: hideOnDefaultLayer,
+                subtitle:
+                    'Automatically hide OverKeys when on the default/base layer. Only show when switching to other layers.',
+                onChanged: updateHideOnDefaultLayer,
               ),
               _buildOpenConfigButton(context),
             ],


### PR DESCRIPTION
…in Advanced tab - Automatically hide OverKeys when on default layer - Only show when switching to other layers - Works with both Kanata integration and user layouts - Closes #119