### PR TITLE
feat: add hotkey to toggle top row visibility

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -233,6 +233,32 @@ class _MainAppState extends ConsumerState<MainApp>
     _setupTray();
   }
 
+  void _toggleTopRow() {
+    final keyboardState = ref.read(keyboardProvider);
+    final keyboardNotifier = ref.read(keyboardProvider.notifier);
+    final newShowTopRow = !keyboardState.showTopRow;
+
+    keyboardNotifier.updateShowTopRow(newShowTopRow);
+    _adjustWindowSize();
+    _autoHideManager.showOverlay(
+      ref,
+      newShowTopRow ? 'Top row shown' : 'Top row hidden',
+      newShowTopRow
+          ? const Icon(LucideIcons.chevronUp)
+          : const Icon(LucideIcons.chevronDown),
+    );
+
+    WindowController.getAll().then((controllers) {
+      for (final controller in controllers) {
+        if (controller.arguments == 'preferences') {
+          controller.invokeMethod('updateShowTopRowFromMainWindow', newShowTopRow);
+        }
+      }
+    });
+
+    _saveAllPreferences();
+  }
+
   void _adjustOpacity(bool increase) {
     final appState = ref.read(appStateProvider);
     final prefsState = ref.read(preferencesProvider);
@@ -332,6 +358,8 @@ class _MainAppState extends ConsumerState<MainApp>
       enableVisibilityHotKey: appState.enableVisibilityHotKey,
       toggleMoveHotKey: appState.toggleMoveHotKey,
       enableToggleMoveHotKey: appState.enableToggleMoveHotKey,
+      toggleTopRowHotKey: appState.toggleTopRowHotKey,
+      enableToggleTopRowHotKey: appState.enableToggleTopRowHotKey,
       preferencesHotKey: appState.preferencesHotKey,
       enablePreferencesHotKey: appState.enablePreferencesHotKey,
       increaseOpacityHotKey: appState.increaseOpacityHotKey,
@@ -358,6 +386,7 @@ class _MainAppState extends ConsumerState<MainApp>
               ref, 'Move enabled', const Icon(LucideIcons.move));
         }
       },
+      onToggleTopRowTriggered: _toggleTopRow,
       onPreferencesTriggered: () {
         _autoHideManager.showOverlay(
             ref, 'Opening Preferences', const Icon(LucideIcons.appWindow));

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -251,7 +251,8 @@ class _MainAppState extends ConsumerState<MainApp>
     WindowController.getAll().then((controllers) {
       for (final controller in controllers) {
         if (controller.arguments == 'preferences') {
-          controller.invokeMethod('updateShowTopRowFromMainWindow', newShowTopRow);
+          controller.invokeMethod(
+              'updateShowTopRowFromMainWindow', newShowTopRow);
         }
       }
     });

--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -18,12 +18,14 @@ class AppState {
   final HotKey? visibilityHotKey;
   final HotKey? autoHideHotKey;
   final HotKey? toggleMoveHotKey;
+  final HotKey? toggleTopRowHotKey;
   final HotKey? preferencesHotKey;
   final HotKey? increaseOpacityHotKey;
   final HotKey? decreaseOpacityHotKey;
   final bool enableVisibilityHotKey;
   final bool enableAutoHideHotKey;
   final bool enableToggleMoveHotKey;
+  final bool enableToggleTopRowHotKey;
   final bool enablePreferencesHotKey;
   final bool enableIncreaseOpacityHotKey;
   final bool enableDecreaseOpacityHotKey;
@@ -45,12 +47,14 @@ class AppState {
     HotKey? visibilityHotKey,
     HotKey? autoHideHotKey,
     HotKey? toggleMoveHotKey,
+    HotKey? toggleTopRowHotKey,
     HotKey? preferencesHotKey,
     HotKey? increaseOpacityHotKey,
     HotKey? decreaseOpacityHotKey,
     this.enableVisibilityHotKey = true,
     this.enableAutoHideHotKey = true,
     this.enableToggleMoveHotKey = true,
+    this.enableToggleTopRowHotKey = true,
     this.enablePreferencesHotKey = true,
     this.enableIncreaseOpacityHotKey = true,
     this.enableDecreaseOpacityHotKey = true,
@@ -70,9 +74,13 @@ class AppState {
             HotKey(
                 key: PhysicalKeyboardKey.keyE,
                 modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
+        toggleTopRowHotKey = toggleTopRowHotKey ??
+            HotKey(
+            key: PhysicalKeyboardKey.keyR,
+                modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
         preferencesHotKey = preferencesHotKey ??
             HotKey(
-                key: PhysicalKeyboardKey.keyR,
+            key: PhysicalKeyboardKey.keyT,
                 modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
         increaseOpacityHotKey = increaseOpacityHotKey ??
             HotKey(
@@ -92,12 +100,14 @@ class AppState {
     HotKey? visibilityHotKey,
     HotKey? autoHideHotKey,
     HotKey? toggleMoveHotKey,
+    HotKey? toggleTopRowHotKey,
     HotKey? preferencesHotKey,
     HotKey? increaseOpacityHotKey,
     HotKey? decreaseOpacityHotKey,
     bool? enableVisibilityHotKey,
     bool? enableAutoHideHotKey,
     bool? enableToggleMoveHotKey,
+    bool? enableToggleTopRowHotKey,
     bool? enablePreferencesHotKey,
     bool? enableIncreaseOpacityHotKey,
     bool? enableDecreaseOpacityHotKey,
@@ -116,6 +126,7 @@ class AppState {
       visibilityHotKey: visibilityHotKey ?? this.visibilityHotKey,
       autoHideHotKey: autoHideHotKey ?? this.autoHideHotKey,
       toggleMoveHotKey: toggleMoveHotKey ?? this.toggleMoveHotKey,
+      toggleTopRowHotKey: toggleTopRowHotKey ?? this.toggleTopRowHotKey,
       preferencesHotKey: preferencesHotKey ?? this.preferencesHotKey,
       increaseOpacityHotKey:
           increaseOpacityHotKey ?? this.increaseOpacityHotKey,
@@ -126,6 +137,8 @@ class AppState {
       enableAutoHideHotKey: enableAutoHideHotKey ?? this.enableAutoHideHotKey,
       enableToggleMoveHotKey:
           enableToggleMoveHotKey ?? this.enableToggleMoveHotKey,
+      enableToggleTopRowHotKey:
+          enableToggleTopRowHotKey ?? this.enableToggleTopRowHotKey,
       enablePreferencesHotKey:
           enablePreferencesHotKey ?? this.enablePreferencesHotKey,
       enableIncreaseOpacityHotKey:
@@ -145,12 +158,14 @@ class AppState {
       'visibilityHotKey': visibilityHotKey?.toJson(),
       'autoHideHotKey': autoHideHotKey?.toJson(),
       'toggleMoveHotKey': toggleMoveHotKey?.toJson(),
+      'toggleTopRowHotKey': toggleTopRowHotKey?.toJson(),
       'preferencesHotKey': preferencesHotKey?.toJson(),
       'increaseOpacityHotKey': increaseOpacityHotKey?.toJson(),
       'decreaseOpacityHotKey': decreaseOpacityHotKey?.toJson(),
       'enableVisibilityHotKey': enableVisibilityHotKey,
       'enableAutoHideHotKey': enableAutoHideHotKey,
       'enableToggleMoveHotKey': enableToggleMoveHotKey,
+      'enableToggleTopRowHotKey': enableToggleTopRowHotKey,
       'enablePreferencesHotKey': enablePreferencesHotKey,
       'enableIncreaseOpacityHotKey': enableIncreaseOpacityHotKey,
       'enableDecreaseOpacityHotKey': enableDecreaseOpacityHotKey,
@@ -175,10 +190,15 @@ class AppState {
           : HotKey(
               key: PhysicalKeyboardKey.keyE,
               modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
+      toggleTopRowHotKey: json['toggleTopRowHotKey'] != null
+          ? HotKey.fromJson(json['toggleTopRowHotKey'])
+          : HotKey(
+            key: PhysicalKeyboardKey.keyR,
+              modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
       preferencesHotKey: json['preferencesHotKey'] != null
           ? HotKey.fromJson(json['preferencesHotKey'])
           : HotKey(
-              key: PhysicalKeyboardKey.keyR,
+            key: PhysicalKeyboardKey.keyT,
               modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
       increaseOpacityHotKey: json['increaseOpacityHotKey'] != null
           ? HotKey.fromJson(json['increaseOpacityHotKey'])
@@ -193,6 +213,8 @@ class AppState {
       enableVisibilityHotKey: json['enableVisibilityHotKey'] as bool? ?? true,
       enableAutoHideHotKey: json['enableAutoHideHotKey'] as bool? ?? true,
       enableToggleMoveHotKey: json['enableToggleMoveHotKey'] as bool? ?? true,
+      enableToggleTopRowHotKey:
+          json['enableToggleTopRowHotKey'] as bool? ?? true,
       enablePreferencesHotKey: json['enablePreferencesHotKey'] as bool? ?? true,
       enableIncreaseOpacityHotKey:
           json['enableIncreaseOpacityHotKey'] as bool? ?? true,
@@ -241,6 +263,10 @@ class AppStateNotifier extends _$AppStateNotifier {
     state = state.copyWith(toggleMoveHotKey: hotKey);
   }
 
+  void updateToggleTopRowHotKey(HotKey hotKey) {
+    state = state.copyWith(toggleTopRowHotKey: hotKey);
+  }
+
   void updatePreferencesHotKey(HotKey hotKey) {
     state = state.copyWith(preferencesHotKey: hotKey);
   }
@@ -263,6 +289,10 @@ class AppStateNotifier extends _$AppStateNotifier {
 
   void updateEnableToggleMoveHotKey(bool value) {
     state = state.copyWith(enableToggleMoveHotKey: value);
+  }
+
+  void updateEnableToggleTopRowHotKey(bool value) {
+    state = state.copyWith(enableToggleTopRowHotKey: value);
   }
 
   void updateEnablePreferencesHotKey(bool value) {

--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -76,11 +76,11 @@ class AppState {
                 modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
         toggleTopRowHotKey = toggleTopRowHotKey ??
             HotKey(
-            key: PhysicalKeyboardKey.keyR,
+                key: PhysicalKeyboardKey.keyR,
                 modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
         preferencesHotKey = preferencesHotKey ??
             HotKey(
-            key: PhysicalKeyboardKey.keyT,
+                key: PhysicalKeyboardKey.keyT,
                 modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
         increaseOpacityHotKey = increaseOpacityHotKey ??
             HotKey(
@@ -193,12 +193,12 @@ class AppState {
       toggleTopRowHotKey: json['toggleTopRowHotKey'] != null
           ? HotKey.fromJson(json['toggleTopRowHotKey'])
           : HotKey(
-            key: PhysicalKeyboardKey.keyR,
+              key: PhysicalKeyboardKey.keyR,
               modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
       preferencesHotKey: json['preferencesHotKey'] != null
           ? HotKey.fromJson(json['preferencesHotKey'])
           : HotKey(
-            key: PhysicalKeyboardKey.keyT,
+              key: PhysicalKeyboardKey.keyT,
               modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
       increaseOpacityHotKey: json['increaseOpacityHotKey'] != null
           ? HotKey.fromJson(json['increaseOpacityHotKey'])

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -110,6 +110,12 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen>
         await _stateService.savePreferencesState(ref.read(preferencesProvider));
       }
 
+      if (call.method == 'updateShowTopRowFromMainWindow' && mounted) {
+        final showTopRow = call.arguments as bool;
+        ref.read(keyboardProvider.notifier).updateShowTopRow(showTopRow);
+        await _stateService.saveKeyboardState(ref.read(keyboardProvider));
+      }
+
       if (call.method == 'requestFocus') {
         await windowManager.focus();
       }

--- a/lib/services/hotkey_service.dart
+++ b/lib/services/hotkey_service.dart
@@ -15,6 +15,8 @@ class HotKeyService {
     required bool enableVisibilityHotKey,
     required HotKey? toggleMoveHotKey,
     required bool enableToggleMoveHotKey,
+    required HotKey? toggleTopRowHotKey,
+    required bool enableToggleTopRowHotKey,
     required HotKey? preferencesHotKey,
     required bool enablePreferencesHotKey,
     required HotKey? increaseOpacityHotKey,
@@ -25,6 +27,7 @@ class HotKeyService {
     required VoidCallback onAutoHideTriggered,
     required VoidCallback onVisibilityTriggered,
     required VoidCallback onToggleMoveTriggered,
+    required VoidCallback onToggleTopRowTriggered,
     required VoidCallback onPreferencesTriggered,
     required VoidCallback onIncreaseOpacityTriggered,
     required VoidCallback onDecreaseOpacityTriggered,
@@ -61,6 +64,16 @@ class HotKeyService {
         keyDownHandler: (hotKey) {
           _log.debug('Move hotkey triggered.');
           onToggleMoveTriggered();
+        },
+      );
+    }
+
+    if (enableToggleTopRowHotKey && toggleTopRowHotKey != null) {
+      await hotKeyManager.register(
+        toggleTopRowHotKey,
+        keyDownHandler: (hotKey) {
+          _log.debug('Toggle top row hotkey triggered.');
+          onToggleTopRowTriggered();
         },
       );
     }

--- a/lib/services/method_call_handler.dart
+++ b/lib/services/method_call_handler.dart
@@ -289,6 +289,17 @@ class MethodCallHandler {
         appNotifier.updateToggleMoveHotKey(newHotKey);
         await setupHotKeys();
 
+      case 'updateToggleTopRowHotKey':
+        final hotKeyJson = _safeArgument<String>(call.arguments, '{}');
+        final newHotKey = HotKey.fromJson(jsonDecode(hotKeyJson));
+        final currentToggleTopRowHotKey =
+            ref.read(appStateProvider).toggleTopRowHotKey;
+        if (currentToggleTopRowHotKey != null) {
+          await hotKeyManager.unregister(currentToggleTopRowHotKey);
+        }
+        appNotifier.updateToggleTopRowHotKey(newHotKey);
+        await setupHotKeys();
+
       case 'updatePreferencesHotKey':
         final hotKeyJson = _safeArgument<String>(call.arguments, '{}');
         final newHotKey = HotKey.fromJson(jsonDecode(hotKeyJson));
@@ -335,6 +346,11 @@ class MethodCallHandler {
       case 'updateEnableToggleMoveHotKey':
         final enabled = _safeArgument<bool>(call.arguments, true);
         appNotifier.updateEnableToggleMoveHotKey(enabled);
+        await setupHotKeys();
+
+      case 'updateEnableToggleTopRowHotKey':
+        final enabled = _safeArgument<bool>(call.arguments, true);
+        appNotifier.updateEnableToggleTopRowHotKey(enabled);
         await setupHotKeys();
 
       case 'updateEnablePreferencesHotKey':

--- a/lib/widgets/tabs/hotkeys_tab.dart
+++ b/lib/widgets/tabs/hotkeys_tab.dart
@@ -102,6 +102,32 @@ class HotKeysTab extends ConsumerWidget {
           isEnabled: appState.hotKeysEnabled,
         ),
         HotKeyOption(
+          label: 'Toggle Top Row',
+          subtitle: 'Show or hide the top number row',
+          formattedHotKey: _formatHotKey(appState.toggleTopRowHotKey),
+          enabled: appState.enableToggleTopRowHotKey,
+          onToggleChanged: (value) {
+            ref
+                .read(appStateProvider.notifier)
+                .updateEnableToggleTopRowHotKey(value);
+            onUpdateMainWindow('updateEnableToggleTopRowHotKey', value);
+          },
+          onChangePressed: () => _showRecordHotKeyDialog(
+            context,
+            (value) {
+              ref
+                  .read(appStateProvider.notifier)
+                  .updateToggleTopRowHotKey(value);
+              onUpdateMainWindow('updateToggleTopRowHotKey', value);
+            },
+            appState.toggleTopRowHotKey ??
+                HotKey(
+                    key: PhysicalKeyboardKey.keyR,
+                    modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
+          ),
+          isEnabled: appState.hotKeysEnabled,
+        ),
+        HotKeyOption(
           label: 'Open Preferences',
           subtitle: 'Show/focus the preferences window',
           formattedHotKey: _formatHotKey(appState.preferencesHotKey),
@@ -122,7 +148,7 @@ class HotKeysTab extends ConsumerWidget {
             },
             appState.preferencesHotKey ??
                 HotKey(
-                    key: PhysicalKeyboardKey.keyR,
+                    key: PhysicalKeyboardKey.keyT,
                     modifiers: [HotKeyModifier.alt, HotKeyModifier.control]),
           ),
           isEnabled: appState.hotKeysEnabled,

--- a/test/providers/app_state_provider_test.dart
+++ b/test/providers/app_state_provider_test.dart
@@ -213,7 +213,7 @@ void main() {
             roundTrip.enableVisibilityHotKey, original.enableVisibilityHotKey);
         expect(roundTrip.enableAutoHideHotKey, original.enableAutoHideHotKey);
         expect(roundTrip.enableToggleTopRowHotKey,
-          original.enableToggleTopRowHotKey);
+            original.enableToggleTopRowHotKey);
       });
 
       test('handles empty JSON', () {

--- a/test/providers/app_state_provider_test.dart
+++ b/test/providers/app_state_provider_test.dart
@@ -17,6 +17,7 @@ void main() {
         expect(state.enableVisibilityHotKey, true);
         expect(state.enableAutoHideHotKey, true);
         expect(state.enableToggleMoveHotKey, true);
+        expect(state.enableToggleTopRowHotKey, true);
         expect(state.enablePreferencesHotKey, true);
         expect(state.showStatusOverlay, false);
         expect(state.overlayMessage, '');
@@ -49,6 +50,7 @@ void main() {
         expect(state.visibilityHotKey, isNotNull);
         expect(state.autoHideHotKey, isNotNull);
         expect(state.toggleMoveHotKey, isNotNull);
+        expect(state.toggleTopRowHotKey, isNotNull);
         expect(state.preferencesHotKey, isNotNull);
         expect(state.increaseOpacityHotKey, isNotNull);
         expect(state.decreaseOpacityHotKey, isNotNull);
@@ -87,17 +89,21 @@ void main() {
         final original = AppState(
           enableVisibilityHotKey: true,
           enableAutoHideHotKey: true,
+          enableToggleTopRowHotKey: true,
         );
 
         final updated = original.copyWith(
           enableVisibilityHotKey: false,
           enableAutoHideHotKey: false,
+          enableToggleTopRowHotKey: false,
         );
 
         expect(updated.enableVisibilityHotKey, false);
         expect(updated.enableAutoHideHotKey, false);
+        expect(updated.enableToggleTopRowHotKey, false);
         expect(original.enableVisibilityHotKey, true);
         expect(original.enableAutoHideHotKey, true);
+        expect(original.enableToggleTopRowHotKey, true);
       });
 
       test('creates copy with updated overlay state', () {
@@ -159,6 +165,7 @@ void main() {
           hotKeysEnabled: false,
           enableVisibilityHotKey: false,
           enableAutoHideHotKey: true,
+          enableToggleTopRowHotKey: false,
         );
 
         final json = state.toJson();
@@ -167,6 +174,7 @@ void main() {
         expect(json['hotKeysEnabled'], false);
         expect(json['enableVisibilityHotKey'], false);
         expect(json['enableAutoHideHotKey'], true);
+        expect(json['enableToggleTopRowHotKey'], false);
         expect(json.containsKey('isWindowVisible'), false); // Not serialized
         expect(json.containsKey('forceHide'), false); // Not serialized
       });
@@ -176,6 +184,7 @@ void main() {
           'hotKeysEnabled': false,
           'enableVisibilityHotKey': false,
           'enableAutoHideHotKey': true,
+          'enableToggleTopRowHotKey': false,
         };
 
         final state = AppState.fromJson(json);
@@ -184,6 +193,7 @@ void main() {
         expect(state.hotKeysEnabled, false);
         expect(state.enableVisibilityHotKey, false);
         expect(state.enableAutoHideHotKey, true);
+        expect(state.enableToggleTopRowHotKey, false);
       });
 
       test('round-trip serialization preserves state', () {
@@ -191,6 +201,7 @@ void main() {
           hotKeysEnabled: false,
           enableVisibilityHotKey: true,
           enableAutoHideHotKey: false,
+          enableToggleTopRowHotKey: false,
         );
 
         final json = original.toJson();
@@ -201,6 +212,8 @@ void main() {
         expect(
             roundTrip.enableVisibilityHotKey, original.enableVisibilityHotKey);
         expect(roundTrip.enableAutoHideHotKey, original.enableAutoHideHotKey);
+        expect(roundTrip.enableToggleTopRowHotKey,
+          original.enableToggleTopRowHotKey);
       });
 
       test('handles empty JSON', () {
@@ -249,6 +262,7 @@ void main() {
           enableVisibilityHotKey: true,
           enableAutoHideHotKey: true,
           enableToggleMoveHotKey: true,
+          enableToggleTopRowHotKey: true,
         );
 
         state = state.copyWith(
@@ -259,6 +273,7 @@ void main() {
         expect(state.enableVisibilityHotKey, false);
         expect(state.enableAutoHideHotKey, false);
         expect(state.enableToggleMoveHotKey, true); // Unchanged
+        expect(state.enableToggleTopRowHotKey, true); // Unchanged
       });
     });
   });

--- a/test/services/state_service_test.dart
+++ b/test/services/state_service_test.dart
@@ -130,6 +130,7 @@ void main() {
           hotKeysEnabled: false,
           enableVisibilityHotKey: false,
           enableAutoHideHotKey: true,
+          enableToggleTopRowHotKey: false,
         );
 
         await stateService.saveAppState(originalState);
@@ -141,6 +142,8 @@ void main() {
             originalState.enableVisibilityHotKey);
         expect(loadedState.enableAutoHideHotKey,
             originalState.enableAutoHideHotKey);
+        expect(loadedState.enableToggleTopRowHotKey,
+          originalState.enableToggleTopRowHotKey);
       });
 
       test('returns null when no app state is saved', () async {

--- a/test/services/state_service_test.dart
+++ b/test/services/state_service_test.dart
@@ -143,7 +143,7 @@ void main() {
         expect(loadedState.enableAutoHideHotKey,
             originalState.enableAutoHideHotKey);
         expect(loadedState.enableToggleTopRowHotKey,
-          originalState.enableToggleTopRowHotKey);
+            originalState.enableToggleTopRowHotKey);
       });
 
       test('returns null when no app state is saved', () async {


### PR DESCRIPTION
This pull request adds a new global hotkey for toggling the visibility of the top row (number row) in the keyboard UI, along with full support for configuring and enabling/disabling this hotkey through the preferences and hotkey management systems. The implementation includes state management, serialization, UI integration, and test coverage for the new feature.

**Hotkey System Enhancements:**

* Added a new `toggleTopRowHotKey` and its enable/disable flag to the `AppState` model, including initialization, serialization, deserialization, and copy methods.
* Updated `AppStateNotifier` with methods to update the new hotkey and its enabled state.
* Extended the `HotKeyService` to register and handle the new hotkey and its callback.
* Modified `MethodCallHandler` to support updating the new hotkey and its enabled state from platform calls.

**UI and Preferences Integration:**

* Added a `HotKeyOption` for "Toggle Top Row" in the hotkeys preferences tab, allowing users to change or enable/disable the hotkey.
* Updated the default keybinding for Preferences to `Ctrl+Alt+T` and assigned `Ctrl+Alt+R` to the new "Toggle Top Row" action.
* Implemented the `_toggleTopRow` method in the main app state, which toggles the top row, updates preferences, and notifies the preferences window.
* Handled the `updateShowTopRowFromMainWindow` method in the preferences screen to synchronize state when triggered from the main window.

**Testing:**

* Added and updated tests to cover the new hotkey and its enabled flag in the `AppState` model and JSON serialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable "Toggle Top Row" hotkey in Preferences with an enable/disable option and transient on-screen feedback.
  * Hotkey settings now persist across sessions and sync between main and preference windows.
  * Reassigned the default "Open Preferences" hotkey from Alt+Ctrl+R to Alt+Ctrl+T.

* **Bug Fixes**
  * Improved reliable propagation of top-row visibility changes across app windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->